### PR TITLE
Re-export qingke-rt::entry

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(naked_functions)]
 
 pub use ch32_metapac as pac;
+pub use qingke_rt::entry;
 
 // This must go FIRST so that all the other modules see its macros.
 include!(concat!(env!("OUT_DIR"), "/_macros.rs"));


### PR DESCRIPTION
Without this, I believe it is not possible for users to use qingke-rt themselves, because the qingke-rt crate defines global symbols which the linker does not like.