### PR TITLE
Fix gptm32 implementation for ch32v20x chips that support it

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -78,6 +78,16 @@ fn main() {
         if let Some(r) = &p.registers {
             println!("cargo:rustc-cfg={}", r.kind);
             println!("cargo:rustc-cfg={}_{}", r.kind, r.version);
+            println!("cargo:rustc-cfg=peri_{}", p.name.to_ascii_lowercase());
+        }
+    }
+
+    // Add cfg flag for any 32-bit timers
+    for p in METADATA.peripherals {
+        if let Some(r) = &p.registers {
+            if r.block == "GPTM32" {
+                println!("cargo:rustc-cfg=gptm32");
+            }
         }
     }
 
@@ -100,7 +110,6 @@ fn main() {
     let mut singletons: Vec<String> = Vec::new();
     for p in METADATA.peripherals {
         if let Some(r) = &p.registers {
-            println!("cargo:rustc-cfg=peri_{}", p.name.to_ascii_lowercase());
             match r.kind {
                 // Generate singletons per pin, not per port
                 "gpio" => {

--- a/build.rs
+++ b/build.rs
@@ -24,15 +24,15 @@ fn main() {
     .unwrap()
     .to_ascii_lowercase();
 
-    // Add family cfg flags on the fly
-    let chip_family = if chip_name.starts_with("ch32") {
-        // On of ch32x0, ch32v0, ch32v1, ch32v2, ch32v3, ch32l1
-        chip_name[..6].to_string()
+    // Add chip name and family cfg flags on the fly
+    let (chip_base_name, chip_family) = if chip_name.starts_with("ch32") {
+        (chip_name[..8].to_string(), chip_name[..6].to_string())
     } else {
         // On of ch643, ch641
-        chip_name[..4].to_string()
+        (chip_name[..4].to_string(), chip_name[..4].to_string())
     };
-    println!("cargo:rustc-cfg={}", chip_family);
+    println!("cargo:rustc-cfg={}", chip_base_name); // ch32v103, ch32v003, ch32x035, ch643, ch641, etc.
+    println!("cargo:rustc-cfg={}", chip_family); // On of ch32x0, ch32v0, ch32v1, ch32v2, ch32v3, ch32l1, ch643, ch641
 
     // Add Qingke IP core version cfg flags on the fly
     // qingke_v2, qingke_v3, qingke_v4
@@ -78,16 +78,6 @@ fn main() {
         if let Some(r) = &p.registers {
             println!("cargo:rustc-cfg={}", r.kind);
             println!("cargo:rustc-cfg={}_{}", r.kind, r.version);
-            println!("cargo:rustc-cfg=peri_{}", p.name.to_ascii_lowercase());
-        }
-    }
-
-    // Add cfg flag for any 32-bit timers
-    for p in METADATA.peripherals {
-        if let Some(r) = &p.registers {
-            if r.block == "GPTM32" {
-                println!("cargo:rustc-cfg=gptm32");
-            }
         }
     }
 
@@ -110,6 +100,7 @@ fn main() {
     let mut singletons: Vec<String> = Vec::new();
     for p in METADATA.peripherals {
         if let Some(r) = &p.registers {
+            println!("cargo:rustc-cfg=peri_{}", p.name.to_ascii_lowercase());
             match r.kind {
                 // Generate singletons per pin, not per port
                 "gpio" => {

--- a/examples/ch32v208/.cargo/config.toml
+++ b/examples/ch32v208/.cargo/config.toml
@@ -1,0 +1,6 @@
+[build]
+target = "riscv32imac-unknown-none-elf"
+
+[target."riscv32imac-unknown-none-elf"]
+runner = "wlink -v flash --enable-sdi-print --watch-serial"
+# runner = "wlink -v flash"

--- a/examples/ch32v208/Cargo.toml
+++ b/examples/ch32v208/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "ch32v208-examples"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ch32-hal = { path = "../../", features = [
+    "ch32v208wbu6",
+    "defmt",
+    "embassy",
+    "rt",
+], default-features = false }
+embassy-executor = { version = "0.5.0", features = [
+    "nightly",
+    "integrated-timers",
+    "arch-riscv32",
+    "executor-thread",
+] }
+embassy-time = { version = "0.3.0" }
+
+qingke-rt = { version = "0.2.0" }
+qingke = { version = "0.2.0" }
+# qingke-rt = { version = "0.2.0", path = "../../../qingke/qingke-rt" }
+# qingke = { version = "0.2.0", path = "../../../qingke" }
+
+panic-halt = "0.2.0"
+
+[profile.release]
+strip = false   # symbols are not flashed to the microcontroller, so don't strip them.
+lto = true
+opt-level = "z" # Optimize for size.

--- a/examples/ch32v208/build.rs
+++ b/examples/ch32v208/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    // println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    // println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/examples/ch32v208/src/bin/blinky.rs
+++ b/examples/ch32v208/src/bin/blinky.rs
@@ -1,0 +1,21 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use hal::gpio::{Level, Output};
+use qingke::riscv;
+use {ch32_hal as hal, panic_halt as _};
+
+#[qingke_rt::entry]
+fn main() -> ! {
+    let p = hal::init(Default::default());
+
+    let mut led = Output::new(p.PB8, Level::Low, Default::default());
+    loop {
+        led.toggle();
+
+        unsafe {
+            riscv::asm::delay(1000000);
+        }
+    }
+}

--- a/src/timer/low_level.rs
+++ b/src/timer/low_level.rs
@@ -188,7 +188,7 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
         Self { tim }
     }
 
-    #[cfg(any(ch32l0, ch32v3))]
+    #[cfg(gptm32)]
     fn regs_gp32_unchecked(&self) -> crate::pac::timer::Gptm32 {
         unsafe { crate::pac::timer::Gptm32::from_ptr(T::regs()) }
     }
@@ -248,7 +248,7 @@ impl<'d, T: BasicInstance> Timer<'d, T> {
                 regs.swevgr().write(|r| r.set_ug(true));
                 regs.ctlr1().modify(|r| r.set_urs(vals::Urs::ANYEVENT));
             }
-            #[cfg(any(ch32l0, ch32v3))]
+            #[cfg(gptm32)]
             TimerBits::Bits32 => {
                 let pclk_ticks_per_timer_period = (timer_f / f) as u64;
                 let psc: u16 = (((pclk_ticks_per_timer_period - 1) / (1 << 32)).try_into()).unwrap();
@@ -303,7 +303,7 @@ impl<'d, T: BasicInstance> Timer<'d, T> {
 
                 timer_f / arr / (psc + 1)
             }
-            #[cfg(any(ch32l0, ch32v3))]
+            #[cfg(gptm32)]
             TimerBits::Bits32 => {
                 let regs = self.regs_gp32_unchecked();
                 let arr = regs.atrlr().read();
@@ -347,7 +347,7 @@ impl<'d, T: GeneralInstance16bit> Timer<'d, T> {
     pub fn get_max_compare_value(&self) -> u32 {
         match T::BITS {
             TimerBits::Bits16 => self.regs_gp16().atrlr().read() as u32,
-            #[cfg(any(ch32l0, ch32v3))]
+            #[cfg(gptm32)]
             TimerBits::Bits32 => self.regs_gp32_unchecked().atrlr().read(),
         }
     }
@@ -466,7 +466,7 @@ impl<'d, T: GeneralInstance16bit> Timer<'d, T> {
                 let value = (u16::try_from(value)).unwrap();
                 self.regs_gp16().chcvr(channel.index()).write_value(value);
             }
-            #[cfg(any(ch32l0, ch32v3))]
+            #[cfg(gptm32)]
             TimerBits::Bits32 => {
                 self.regs_gp32_unchecked().chcvr(channel.index()).write_value(value);
             }
@@ -477,7 +477,7 @@ impl<'d, T: GeneralInstance16bit> Timer<'d, T> {
     pub fn get_compare_value(&self, channel: Channel) -> u32 {
         match T::BITS {
             TimerBits::Bits16 => self.regs_gp16().chcvr(channel.index()).read() as u32,
-            #[cfg(any(ch32l0, ch32v3))]
+            #[cfg(gptm32)]
             TimerBits::Bits32 => self.regs_gp32_unchecked().chcvr(channel.index()).read(),
         }
     }

--- a/src/timer/low_level.rs
+++ b/src/timer/low_level.rs
@@ -188,7 +188,7 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
         Self { tim }
     }
 
-    #[cfg(gptm32)]
+    #[cfg(any(ch32l1, ch32v208))]
     fn regs_gp32_unchecked(&self) -> crate::pac::timer::Gptm32 {
         unsafe { crate::pac::timer::Gptm32::from_ptr(T::regs()) }
     }
@@ -248,7 +248,7 @@ impl<'d, T: BasicInstance> Timer<'d, T> {
                 regs.swevgr().write(|r| r.set_ug(true));
                 regs.ctlr1().modify(|r| r.set_urs(vals::Urs::ANYEVENT));
             }
-            #[cfg(gptm32)]
+            #[cfg(any(ch32l1, ch32v208))]
             TimerBits::Bits32 => {
                 let pclk_ticks_per_timer_period = (timer_f / f) as u64;
                 let psc: u16 = (((pclk_ticks_per_timer_period - 1) / (1 << 32)).try_into()).unwrap();
@@ -303,7 +303,7 @@ impl<'d, T: BasicInstance> Timer<'d, T> {
 
                 timer_f / arr / (psc + 1)
             }
-            #[cfg(gptm32)]
+            #[cfg(any(ch32l1, ch32v208))]
             TimerBits::Bits32 => {
                 let regs = self.regs_gp32_unchecked();
                 let arr = regs.atrlr().read();
@@ -347,7 +347,7 @@ impl<'d, T: GeneralInstance16bit> Timer<'d, T> {
     pub fn get_max_compare_value(&self) -> u32 {
         match T::BITS {
             TimerBits::Bits16 => self.regs_gp16().atrlr().read() as u32,
-            #[cfg(gptm32)]
+            #[cfg(any(ch32l1, ch32v208))]
             TimerBits::Bits32 => self.regs_gp32_unchecked().atrlr().read(),
         }
     }
@@ -466,7 +466,7 @@ impl<'d, T: GeneralInstance16bit> Timer<'d, T> {
                 let value = (u16::try_from(value)).unwrap();
                 self.regs_gp16().chcvr(channel.index()).write_value(value);
             }
-            #[cfg(gptm32)]
+            #[cfg(any(ch32l1, ch32v208))]
             TimerBits::Bits32 => {
                 self.regs_gp32_unchecked().chcvr(channel.index()).write_value(value);
             }
@@ -477,7 +477,7 @@ impl<'d, T: GeneralInstance16bit> Timer<'d, T> {
     pub fn get_compare_value(&self, channel: Channel) -> u32 {
         match T::BITS {
             TimerBits::Bits16 => self.regs_gp16().chcvr(channel.index()).read() as u32,
-            #[cfg(gptm32)]
+            #[cfg(any(ch32l1, ch32v208))]
             TimerBits::Bits32 => self.regs_gp32_unchecked().chcvr(channel.index()).read(),
         }
     }

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -50,7 +50,7 @@ pub enum TimerBits {
     /// 16 bits.
     Bits16,
     /// 32 bits.
-    #[cfg(any(ch32l0, ch32v3))]
+    #[cfg(gptm32)]
     Bits32,
 }
 

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -50,7 +50,7 @@ pub enum TimerBits {
     /// 16 bits.
     Bits16,
     /// 32 bits.
-    #[cfg(gptm32)]
+    #[cfg(any(ch32l1, ch32v208))]
     Bits32,
 }
 


### PR DESCRIPTION
The following chips have a 32-bit GPTM (on TIM5):
- ch32v203rbt6
- ch32v208cbu6
- ch32v208gbu6
- ch32v208rbt6
- ch32v208wbu6

When building for these chips, there is an error due to `TimerBits::Bits32` not being conditionally compiled.

Let me know if there's a better way to fix this other than adding a cfg flag, thanks