### PR TITLE
Implement I2C for embedded-hal-async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
     "unproven",
 ] }
 embedded-hal = { package = "embedded-hal", version = "1.0" }
+embedded-hal-async = "1.0.0"
 
 critical-section = { version = "1.1.2" }
 defmt = { version = "0.3.5", optional = true }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -971,6 +971,30 @@ impl<'d, T: Instance, M: Mode> embedded_hal::i2c::I2c for I2c<'d, T, M> {
     }
 }
 
+impl<'d, T: Instance> embedded_hal_async::i2c::I2c for I2c<'d, T, Async> {
+    async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
+        self.read(address, read).await
+    }
+
+    async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
+        self.write(address, write).await
+    }
+
+    async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
+        self.write_read(address, write, read).await
+    }
+
+    async fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [embedded_hal_async::i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        let _ = address;
+        let _ = operations;
+        todo!()
+    }
+}
+
 // eh02 compatible
 
 impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Read for I2c<'d, T, M> {


### PR DESCRIPTION
Allows using HAL with async device drivers.