### PR TITLE
Feature/qingke v4 delay

### DIFF
--- a/examples/ch32v307/src/bin/blinky.rs
+++ b/examples/ch32v307/src/bin/blinky.rs
@@ -3,39 +3,19 @@
 #![feature(type_alias_impl_trait)]
 #![feature(impl_trait_in_assoc_type)]
 
-use embassy_executor::Spawner;
-use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::delay::Delay;
+use hal::gpio::{Level, Output};
 use {ch32_hal as hal, panic_halt as _};
 
-#[embassy_executor::task(pool_size = 3)]
-async fn blink(pin: AnyPin, interval_ms: u64) {
-    let mut led = Output::new(pin, Level::Low, Default::default());
-
-    loop {
-        led.set_high();
-        Timer::after(Duration::from_millis(interval_ms)).await;
-        led.set_low();
-        Timer::after(Duration::from_millis(interval_ms)).await;
-    }
-}
-
-#[embassy_executor::main(entry = "qingke_rt::entry")]
-async fn main(spawner: Spawner) -> ! {
-    hal::debug::SDIPrint::enable();
+#[qingke_rt::entry]
+fn main() -> ! {
     let p = hal::init(Default::default());
-    hal::println!("init embassy");
 
-    hal::embassy::init();
+    let mut led = Output::new(p.PA15, Level::Low, Default::default());
+    let mut delay = Delay;
 
-    hal::println!("init ok");
-
-    // GPIO
-    spawner.spawn(blink(p.PA15.degrade(), 1000)).unwrap();
-    spawner.spawn(blink(p.PB4.degrade(), 500)).unwrap();
-    // spawner.spawn(blink(p.PB8.degrade(), 100)).unwrap();
     loop {
-        Timer::after_millis(2000).await;
-        hal::println!("tick");
+        led.toggle();
+        delay.delay_ms(1000);
     }
 }

--- a/examples/ch32v307/src/bin/embassy_blinky.rs
+++ b/examples/ch32v307/src/bin/embassy_blinky.rs
@@ -1,0 +1,35 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
+
+use embassy_executor::Spawner;
+use embassy_time::{Duration, Timer};
+use hal::gpio::{AnyPin, Level, Output, Pin};
+use {ch32_hal as hal, panic_halt as _};
+
+#[embassy_executor::task(pool_size = 3)]
+async fn blink(pin: AnyPin, interval_ms: u64) {
+    let mut led = Output::new(pin, Level::Low, Default::default());
+
+    loop {
+        led.set_high();
+        Timer::after(Duration::from_millis(interval_ms)).await;
+        led.set_low();
+        Timer::after(Duration::from_millis(interval_ms)).await;
+    }
+}
+
+#[embassy_executor::main(entry = "qingke_rt::entry")]
+async fn main(spawner: Spawner) -> ! {
+    let p = hal::init(Default::default());
+    hal::embassy::init();
+
+    // GPIO
+    spawner.spawn(blink(p.PA15.degrade(), 1000)).unwrap();
+    spawner.spawn(blink(p.PB4.degrade(), 100)).unwrap();
+    // spawner.spawn(blink(p.PB8.degrade(), 100)).unwrap();
+    loop {
+        Timer::after_millis(2000).await;
+    }
+}

--- a/src/delay/impl_qingke_v2_v4.rs
+++ b/src/delay/impl_qingke_v2_v4.rs
@@ -1,4 +1,4 @@
-//! SYSTICK based delay implementation for Qingke V2
+//! SYSTICK based delay implementation for Qingke V2 and V4
 
 use pac::systick::vals;
 

--- a/src/delay/mod.rs
+++ b/src/delay/mod.rs
@@ -1,5 +1,5 @@
-#[cfg(qingke_v2)]
-#[path = "./impl_qingke_v2.rs"]
+#[cfg(any(qingke_v2, qingke_v4))]
+#[path = "./impl_qingke_v2_v4.rs"]
 mod delay_impl;
 
 #[cfg(qingke_v3)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ mod interrupt_ext;
 
 pub use crate::_generated::{peripherals, Peripherals};
 
-#[cfg(any(systick_rv2, systick_rv3))]
+#[cfg(any(systick_rv2, systick_rv3, systick_rv4))]
 pub mod delay;
 pub mod dma;
 
@@ -115,7 +115,7 @@ pub fn init(config: Config) -> Peripherals {
     unsafe {
         rcc::init(config.rcc);
 
-        #[cfg(any(systick_rv2, systick_rv3))]
+        #[cfg(any(systick_rv2, systick_rv3, systick_rv4))]
         delay::Delay::init();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ mod interrupt_ext;
 
 pub use crate::_generated::{peripherals, Peripherals};
 
-#[cfg(any(systick_rv2, systick_rv3, systick_rv4))]
+#[cfg(not(time_driver_systick))]
 pub mod delay;
 pub mod dma;
 


### PR DESCRIPTION
To close https://github.com/ch32-rs/ch32-hal/issues/27 I have looked at the QingKeV4 Microprocessor Manual and the register names are the same for the QingKeV2 and QingKeV4 except than on QingKeV2 the Systick timer is 32-bit and on the QingKeV4 it is a 64-bit timer.
But given the implementation, we reset the timer to 0 for each delay and `delay_ns()` takes a `u32` so I had the same implementation for both processors, hence the use of the same file.

I have also included a basic example without embassy. I have renamed the blinky using embassy `embassy_blinky` to use the `embassy_` prefix as done in [`esp-hal` examples](https://github.com/esp-rs/esp-hal/tree/main/examples/src/bin). Let me know if you are ok with this. I can rename the other examples for more consistency.

Note that according to the issue https://github.com/ch32-rs/ch32-hal/issues/6 I had to make these changes to run the examples:
```patch
diff --git a/Cargo.toml b/Cargo.toml
index b7750e4..24752da 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ defmt = { version = "0.3.5", optional = true }
 embassy-sync = { version = "0.6.0", optional = true }
 embassy-futures = { version = "0.1.1", optional = true }
 embassy-time-driver = { version = "0.1.0", features = [
-    "tick-hz-1_000_000",
+    "tick-hz-10_000",
 ], optional = true }
 embassy-time = { version = "0.3.0", features = [
-    "tick-hz-1_000_000",
+    "tick-hz-10_000",
 ], optional = true }
 embassy-usb-driver = "0.1.0"
 
diff --git a/examples/ch32v307/Cargo.toml b/examples/ch32v307/Cargo.toml
index eda3ed0..c1008f6 100644
--- a/examples/ch32v307/Cargo.toml
+++ b/examples/ch32v307/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ch32-hal = { path = "../../", features = ["ch32v307vct6", "embassy", "rt"] }
+ch32-hal = { path = "../../", features = ["ch32v305rbt6", "embassy", "rt"] }
 embassy-executor = { version = "0.5.0", features = [
     "nightly",
     "integrated-timers",
```