### PR TITLE
fix(build): add common toolchain components

### DIFF
--- a/examples/ch32v003/rust-toolchain.toml
+++ b/examples/ch32v003/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "nightly-2024-06-12"
+components = [ "rust-src", "rustfmt", "llvm-tools" ]

--- a/examples/ch641/rust-toolchain.toml
+++ b/examples/ch641/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "nightly-2024-06-12"
+components = [ "rust-src", "rustfmt", "llvm-tools" ]


### PR DESCRIPTION
Targets that are not tier2 or above require `build-std`, which in turn requires `rust-src`
Add `rust-src` and other common tools to targets with a custom target file so these are installed automatically for the user.