### PR TITLE
bugfix(broken atomic): atomic removal

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -23,8 +23,7 @@ jobs:
           rustup default nightly
           rustup component add rust-src
           rustup update
-          rustup target add riscv32imac-unknown-none-elf
-          rustup target add riscv32imafc-unknown-none-elf
+          rustup target add riscv32imc-unknown-none-elf
           rustup target add riscv32i-unknown-none-elf
       - name: Fetch Deps
         # if this is a pull request

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,23 +30,27 @@ jobs:
           - ch641
         include:
           - chip: ch32l103f8u6
-            target: riscv32imac-unknown-none-elf
+            target: riscv32imc-unknown-none-elf
           - chip: ch32v003f4u6
             target: riscv32i-unknown-none-elf
           - chip: ch32v103c8t6
-            target: riscv32imac-unknown-none-elf
+            target: riscv32imc-unknown-none-elf
           - chip: ch32v203f8u6
-            target: riscv32imac-unknown-none-elf
+            target: riscv32imc-unknown-none-elf
           - chip: ch32v208wbu6
-            target: riscv32imac-unknown-none-elf
+            target: riscv32imc-unknown-none-elf
           - chip: ch32v303vct6
-            target: riscv32imafc-unknown-none-elf
+            # use rv32imc because ri32imfc does not exist, hal should not use FP anyways
+            target: riscv32imc-unknown-none-elf
           - chip: ch32v305fbp6
-            target: riscv32imafc-unknown-none-elf
+            # use rv32imc because ri32imfc does not exist
+            target: riscv32imc-unknown-none-elf
           - chip: ch32v307vct6
-            target: riscv32imafc-unknown-none-elf
+            # use rv32imc because ri32imfc does not exist
+            target: riscv32imc-unknown-none-elf
           - chip: ch32x035f7p6
-            target: riscv32imafc-unknown-none-elf
+            # use rv32imc because ri32imfc does not exist
+            target: riscv32imc-unknown-none-elf
           - chip: ch641
             target: riscv32i-unknown-none-elf
     runs-on: ubuntu-latest
@@ -57,8 +61,7 @@ jobs:
           rustup default nightly
           rustup component add rust-src
           rustup update
-          rustup target add riscv32imac-unknown-none-elf
-          rustup target add riscv32imafc-unknown-none-elf
+          rustup target add riscv32imc-unknown-none-elf
           rustup target add riscv32i-unknown-none-elf
       - name: Fetch Deps
         # if this is a pull request

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ ch32-metapac = { features = [
     "rt",
 ], git = "https://github.com/ch32-rs/ch32-metapac", rev = "cef1944dadf3a5d198e687500b8f5964f29efdf6" }
 
-qingke = { version = "0.4.0", features = ["critical-section-impl"] }
-qingke-rt = { version = "0.4.0", optional = true }
+qingke = { version = "0.5.0", features = ["critical-section-impl"] }
+qingke-rt = { version = "0.5.0", optional = true }
 
 # TODO: remove this
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [

--- a/examples/ch32l103/.cargo/config.toml
+++ b/examples/ch32l103/.cargo/config.toml
@@ -1,6 +1,6 @@
 [build]
-target = "riscv32imac-unknown-none-elf"
+target = "riscv32imc-unknown-none-elf"
 
-[target."riscv32imac-unknown-none-elf"]
+[target."riscv32imc-unknown-none-elf"]
 runner = "wlink -v flash --enable-sdi-print --watch-serial"
 # runner = "wlink -v flash"

--- a/examples/ch32l103/Cargo.toml
+++ b/examples/ch32l103/Cargo.toml
@@ -18,15 +18,17 @@ embassy-executor = { version = "0.6.0", features = [
 ] }
 embassy-time = { version = "0.3.2" }
 
-qingke-rt = { version = "0.4.0" }
-qingke = "0.4.0"
-# qingke-rt = { version = "0.4.0", path = "../../../qingke/qingke-rt" }
-# qingke = { version = "0.4.0", path = "../../../qingke" }
+# This is okay because we should automatically use whatever ch32-hal uses
+qingke = "*"
+qingke-rt = "*"
 
-panic-halt = "0.2.0"
+panic-halt = "1.0"
 embedded-hal = "1.0.0"
 
 [profile.release]
 strip = false   # symbols are not flashed to the microcontroller, so don't strip them.
 lto = true
 opt-level = "z" # Optimize for size.
+
+[profile.dev]
+opt-level = 1 # At least some opt so binary is not insane

--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -13,19 +13,18 @@ ch32-hal = { path = "../../", features = [
 ] }
 embassy-executor = { version = "0.6.0", features = [
     "integrated-timers",
-    "arch-riscv32",
+    "arch-spin",
     "executor-thread",
     "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
 ] }
 embassy-time = { version = "0.3.0" }
 
-qingke-rt = { version = "0.4.0", features = ["highcode"] }
-qingke = "0.4.0"
-# qingke-rt = { version = "0.4.0", path = "../../../qingke/qingke-rt" }
-# qingke = { version = "0.4.0", path = "../../../qingke" }
+# This is okay because we should automatically use whatever ch32-hal uses
+qingke = "*"
+qingke-rt = { version = "*", features = ["highcode"] }
 
 
-panic-halt = "0.2.0"
+panic-halt = "1.0"
 
 embedded-hal = "1.0.0"
 

--- a/examples/ch32v103/.cargo/config.toml
+++ b/examples/ch32v103/.cargo/config.toml
@@ -1,7 +1,7 @@
 [build]
-target = "riscv32imac-unknown-none-elf"
+target = "riscv32imc-unknown-none-elf"
 
-[target."riscv32imac-unknown-none-elf"]
+[target."riscv32imc-unknown-none-elf"]
 rustflags = [
 #  "-C", "link-arg=-Tlink.x",
 ]

--- a/examples/ch32v103/Cargo.toml
+++ b/examples/ch32v103/Cargo.toml
@@ -12,21 +12,20 @@ ch32-hal = { path = "../../", features = [
 ] }
 embassy-executor = { version = "0.6.0", features = [
     "integrated-timers",
-    "arch-riscv32",
+    "arch-spin",
     "executor-thread",
 ] }
 embassy-time = { version = "0.3.2" }
 
-qingke-rt = "0.4.0"
-qingke = "0.4.0"
-# qingke-rt = { version = "0.4.0", path = "../../../qingke/qingke-rt" }
-# qingke = { version = "0.4.0", path = "../../../qingke" }
+# This is okay because we should automatically use whatever ch32-hal uses
+qingke-rt = "*"
+qingke = "*"
 
 # Not working for now
 # defmt = "0.3"
 # defmt-rtt = "0.4"
 
-panic-halt = "0.2.0"
+panic-halt = "1.0"
 
 display-interface-spi = "0.5.0"
 mipidsi = "0.7.1"

--- a/examples/ch32v203/.cargo/config.toml
+++ b/examples/ch32v203/.cargo/config.toml
@@ -1,7 +1,7 @@
 [build]
-target = "riscv32imac-unknown-none-elf"
+target = "riscv32imc-unknown-none-elf"
 
-[target."riscv32imac-unknown-none-elf"]
+[target."riscv32imc-unknown-none-elf"]
 rustflags = [
 #  "-C", "link-arg=-Tlink.x",
 ]

--- a/examples/ch32v203/Cargo.toml
+++ b/examples/ch32v203/Cargo.toml
@@ -11,25 +11,22 @@ ch32-hal = { path = "../../", features = [
     "rt",
     "time-driver-tim2",
 ], default-features = false }
-#ch32-metapac = { features = [
-#    "memory-x",
-#    "rt",
-#], path = "../../../ch32-data/build/ch32-metapac" }
+
 embassy-executor = { version = "0.6.0", features = [
     "integrated-timers",
     "arch-riscv32",
     "executor-thread",
 ] }
+
 embassy-time = { version = "0.3.2" }
 embassy-usb = { version = "0.3.0" }
 embassy-futures = { version = "0.1.0" }
 
-qingke-rt = "0.4.0"
-qingke = "0.4.0"
-#qingke-rt = { version = "0.4.0", path = "../../../qingke/qingke-rt" }
-# qingke = { version = "0.4.0", path = "../../../qingke" }
+# This is okay because we should automatically use whatever ch32-hal uses
+qingke-rt = "*"
+qingke = "*"
 
-panic-halt = "0.2.0"
+panic-halt = "1.0"
 
 display-interface-spi = "0.5.0"
 embedded-hal = "1.0.0"

--- a/examples/ch32v208/.cargo/config.toml
+++ b/examples/ch32v208/.cargo/config.toml
@@ -1,6 +1,6 @@
 [build]
-target = "riscv32imac-unknown-none-elf"
+target = "riscv32imc-unknown-none-elf"
 
-[target."riscv32imac-unknown-none-elf"]
+[target."riscv32imc-unknown-none-elf"]
 runner = "wlink -v flash --enable-sdi-print --watch-serial"
 # runner = "wlink -v flash"

--- a/examples/ch32v208/Cargo.toml
+++ b/examples/ch32v208/Cargo.toml
@@ -17,12 +17,11 @@ embassy-executor = { version = "0.6.0", features = [
 ] }
 embassy-time = { version = "0.3.2" }
 
-qingke-rt = "0.4.0"
-qingke = "0.4.0"
-# qingke-rt = { version = "0.4.0", path = "../../../qingke/qingke-rt" }
-# qingke = { version = "0.4.0", path = "../../../qingke" }
+# This is okay because we should automatically use whatever ch32-hal uses
+qingke-rt = "*"
+qingke = "*"
 
-panic-halt = "0.2.0"
+panic-halt = "1.0"
 
 [profile.release]
 strip = false   # symbols are not flashed to the microcontroller, so don't strip them.

--- a/examples/ch32v305/.cargo/config.toml
+++ b/examples/ch32v305/.cargo/config.toml
@@ -1,7 +1,10 @@
 [build]
-target = "riscv32imafc-unknown-none-elf"
+target = "riscv32imfc-unknown-none-elf.json"
 
-[target.riscv32imafc-unknown-none-elf]
+[unstable]
+build-std = ["core"]
+
+[target.riscv32imfc-unknown-none-elf]
 # runner = "wlink flash --enable-sdi-print --watch-serial"
 runner = "wlink flash"
 

--- a/examples/ch32v305/Cargo.toml
+++ b/examples/ch32v305/Cargo.toml
@@ -17,28 +17,28 @@ embassy-executor = { version = "0.6.0", features = [
 ] }
 embassy-time = { version = "0.3.2" }
 
-qingke-rt = "0.4.0"
-qingke = "0.4.0"
-# qingke-rt = { version = "0.4.0", path = "../../../qingke/qingke-rt" }
-# qingke = { version = "0.4.0", path = "../../../qingke" }
+qingke-rt = "*"
+qingke = "*"
 
-# Not working for now
-# defmt = "0.3"
-# defmt-rtt = "0.4"
+panic-halt = "1.0"
 
-panic-halt = "0.2.0"
+portable-atomic = { version = "1", default-features = false, features = [
+    "critical-section",
+] }
 
 display-interface-spi = "0.5.0"
-mipidsi = "0.7.1"
 embedded-graphics = "0.8.1"
 embedded-hal-bus = "0.1.0"
 embedded-hal = "1.0.0"
 micromath = "2.1.0"
 nb = "1.1.0"
-heapless = "0.8.0"
+heapless = { version = "0.8.0", features = ["portable-atomic"] }
 
 
 [profile.release]
 strip = false   # symbols are not flashed to the microcontroller, so don't strip them.
 lto = true
 opt-level = "z" # Optimize for size.
+
+[profile.dev]
+opt-level = 2 # At least some opt so binary size is not insane

--- a/examples/ch32v305/riscv32imfc-unknown-none-elf.json
+++ b/examples/ch32v305/riscv32imfc-unknown-none-elf.json
@@ -1,0 +1,19 @@
+{
+  "arch": "riscv32",
+  "atomic-cas": false,
+  "cpu": "generic-rv32",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p:32:32-i64:64-n32-S128",
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "features": "+m,+f,+c,+forced-atomics",
+  "is-builtin": false,
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-abiname": "ilp32f",
+  "llvm-target": "riscv32",
+  "max-atomic-width": 32,
+  "panic-strategy": "abort",
+  "relocation-model": "static",
+  "target-pointer-width": "32"
+}

--- a/examples/ch32v307/.cargo/config.toml
+++ b/examples/ch32v307/.cargo/config.toml
@@ -1,7 +1,10 @@
 [build]
-target = "riscv32imafc-unknown-none-elf"
+target = "riscv32imfc-unknown-none-elf.json"
 
-[target.riscv32imafc-unknown-none-elf]
+[unstable]
+build-std = ["core"]
+
+[target.riscv32imfc-unknown-none-elf]
 runner = "wlink flash --enable-sdi-print --watch-serial"
 # runner = "wlink -v flash --no-erase --dry-run"
 # runner = "probe-rs run --chip CH32V307"

--- a/examples/ch32v307/Cargo.toml
+++ b/examples/ch32v307/Cargo.toml
@@ -24,19 +24,14 @@ embassy-time = "0.3.2"
 embassy-usb = "0.3.0"
 nb = "1.1.0"
 
-qingke = "0.4.0"
-qingke-rt = "0.4.0"
+# This is okay because we should automatically use whatever ch32-hal uses
+qingke = "*"
+qingke-rt = "*"
 
-# Not working for now
-# defmt = "0.3"
-# defmt-rtt = "0.4"
-
-panic-halt = "0.2.0"
+panic-halt = "1.0"
 
 display-interface-spi = "0.5.0"
-mipidsi = "0.7.1"
 embedded-graphics = "0.8.1"
-embedded-hal-bus = "0.2.0"
 # for ssd1306
 ssd1306 = "0.9"
 

--- a/examples/ch32v307/riscv32imfc-unknown-none-elf.json
+++ b/examples/ch32v307/riscv32imfc-unknown-none-elf.json
@@ -1,0 +1,19 @@
+{
+  "arch": "riscv32",
+  "atomic-cas": false,
+  "cpu": "generic-rv32",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p:32:32-i64:64-n32-S128",
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "features": "+m,+f,+c,+forced-atomics",
+  "is-builtin": false,
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-abiname": "ilp32f",
+  "llvm-target": "riscv32",
+  "max-atomic-width": 32,
+  "panic-strategy": "abort",
+  "relocation-model": "static",
+  "target-pointer-width": "32"
+}

--- a/examples/ch32x035/.cargo/config.toml
+++ b/examples/ch32x035/.cargo/config.toml
@@ -1,7 +1,7 @@
 [build]
-target = "riscv32imac-unknown-none-elf"
+target = "riscv32imc-unknown-none-elf"
 
-[target.riscv32imac-unknown-none-elf]
+[target.riscv32imc-unknown-none-elf]
 runner = "wlink flash --enable-sdi-print --watch-serial"
 # runner = "wlink -v flash --no-erase --dry-run"
 # runner = "probe-rs run --chip CH32V307"

--- a/examples/ch32x035/Cargo.toml
+++ b/examples/ch32x035/Cargo.toml
@@ -17,17 +17,14 @@ embassy-executor = { version = "0.6.0", features = [
 ] }
 embassy-time = { version = "0.3.2" }
 
-qingke-rt = "0.4.0"
-qingke = "0.4.0"
-# qingke-rt = { version = "0.4.0", path = "../../../qingke/qingke-rt" }
-# qingke = { version = "0.4.0", path = "../../../qingke" }
+qingke-rt = "*"
+qingke = "*"
 
-panic-halt = "0.2.0"
+panic-halt = "1.0"
 
 display-interface-spi = "0.5.0"
 mipidsi = "0.7.1"
 embedded-graphics = "0.8.1"
-embedded-hal-bus = "0.2.0"
 embedded-hal = "1.0.0"
 heapless = "0.8.0"
 

--- a/examples/ch641/Cargo.toml
+++ b/examples/ch641/Cargo.toml
@@ -18,17 +18,12 @@ embassy-executor = { version = "0.6.0", features = [
     "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
 ] }
 embassy-time = { version = "0.3.2" }
-
-qingke-rt = "0.4.0"
-qingke = "0.4.0"
-# qingke-rt = { version = "0.4.0", path = "../../../qingke/qingke-rt" }
-# qingke = { version = "0.4.0", path = "../../../qingke" }
-
-
-panic-halt = "0.2.0"
-
 embedded-hal = "1.0.0"
 
+qingke-rt = "*"
+qingke = "*"
+
+panic-halt = "1.0"
 
 [profile.release]
 strip = false   # symbols are not flashed to the microcontroller, so don't strip them.


### PR DESCRIPTION
As discovered in #59, the QingKeV4 atomic implementation is likely broken. As a result we added a compiler check to make sure the atomic exetnsion is disabled in ch32-rs/qingke#8. This change updates the dependency to use the new qingke as well as remove any reference to `core::atomic` in ch32-hal.