### PR TITLE
Misc fixes for OTG_FS and enable building on stable toolchain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![allow(static_mut_refs, unexpected_cfgs)]
-#![feature(naked_functions)]
 
 pub use ch32_metapac as pac;
 pub(crate) use embassy_hal_internal::{impl_peripheral, peripherals_definition, peripherals_struct};

--- a/src/otg_fs/endpoint.rs
+++ b/src/otg_fs/endpoint.rs
@@ -250,7 +250,7 @@ where
         .await
     }
 
-    async fn data_out(&mut self, buf: &mut [u8], first: bool, last: bool) -> Result<usize, EndpointError> {
+    async fn data_out(&mut self, buf: &mut [u8], first: bool, _last: bool) -> Result<usize, EndpointError> {
         let regs = T::regs();
 
         if buf.len() > self.ep0_buf.max_packet_size as usize {


### PR DESCRIPTION
@ExplodingWaffle pointed out[1] the host is allowed to send a shorter
packet than what we were expecting. Remove the assertions and links to
embassy.

[1] https://github.com/ch32-rs/ch32-hal/issues/59#issuecomment-2451634832

Also remove the naked_functions declaration as we don't use it anymore.