### PR TITLE
ch32v003 i2c shared example

### DIFF
--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -11,10 +11,12 @@ ch32-hal = { path = "../../", features = [
     "time-driver-tim2",
     "rt",
 ] }
+embassy-embedded-hal = "0.5.0"
 embassy-executor = { version = "0.9.1", features = [
     "arch-spin",
     "executor-thread",
 ] }
+embassy-sync = "0.7.2"
 embassy-time = "0.5.0"
 
 # This is okay because we should automatically use whatever ch32-hal uses
@@ -28,6 +30,8 @@ embedded-hal = "1.0.0"
 display-interface-spi = "0.5.0"
 embedded-graphics = "0.8.1"
 micromath = { version = "2.1.0", features = ["num-traits"] }
+# riscv =  { version="0.12.1",features = ["critical-section-single-hart"] }
+static_cell = "1.3.0"
 
 [profile.release]
 strip = false   # symbols are not flashed to the microcontroller, so don't strip them.
@@ -40,4 +44,3 @@ overflow-checks = false
 # [patch.crates-io]
 # qingke = { path = "../../../qingke" }
 # qingke-rt = { path = "../../../qingke/qingke-rt" }
-

--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -30,8 +30,7 @@ embedded-hal = "1.0.0"
 display-interface-spi = "0.5.0"
 embedded-graphics = "0.8.1"
 micromath = { version = "2.1.0", features = ["num-traits"] }
-# riscv =  { version="0.12.1",features = ["critical-section-single-hart"] }
-static_cell = "1.3.0"
+embedded-hal-async = "1.0.0"
 
 [profile.release]
 strip = false   # symbols are not flashed to the microcontroller, so don't strip them.

--- a/examples/ch32v003/src/bin/embassy_i2c_shared_bus.rs
+++ b/examples/ch32v003/src/bin/embassy_i2c_shared_bus.rs
@@ -1,44 +1,72 @@
-//! This example shows how to share (async) I2C buses between multiple devices with embassy.
-
+//! This example shows how to share an async I2C bus between multiple devices with embassy.
+//! This allows you to have multiple devices on the same bus.
 #![no_std]
 #![no_main]
 
 use ch32_hal::gpio::{Level, Output};
 use ch32_hal::i2c::I2c;
-use ch32_hal::mode::Blocking;
-// use ch32_hal::pac::I2C1;
 use ch32_hal::time::Hertz;
-use embassy_embedded_hal::shared_bus::blocking::i2c::I2cDevice;
+use ch32_hal::{bind_interrupts, println};
+use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
 use embassy_executor::Spawner;
-use embassy_sync::blocking_mutex::{Mutex, NoopMutex};
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
 use embassy_time::Timer;
 use panic_halt as _;
-use static_cell::StaticCell;
 
-type I2cBus = NoopMutex<I2c<'static, ch32_hal::peripherals::I2C1, Blocking>>;
+bind_interrupts!(struct Irqs {
+    I2C1_EV => ch32_hal::i2c::EventInterruptHandler<ch32_hal::peripherals::I2C1>;
+    I2C1_ER => ch32_hal::i2c::ErrorInterruptHandler<ch32_hal::peripherals::I2C1>;
+});
+
+type I2cBus = Mutex<NoopRawMutex, I2c<'static, ch32_hal::peripherals::I2C1, ch32_hal::mode::Async>>;
 
 #[embassy_executor::main(entry = "qingke_rt::entry")]
-async fn main(spawner: Spawner) -> ! {
+async fn main(_spawner: Spawner) -> ! {
     ch32_hal::debug::SDIPrint::enable();
     let p = ch32_hal::init(ch32_hal::Config::default());
+    //Check your board for the correct pin. This is for the nanoCH32V003 Development Board
     let mut led = Output::new(p.PD6, Level::Low, Default::default());
 
-    led.set_high();
+    //Sets up an async i2c
     let scl = p.PC2;
     let sda = p.PC1;
-    let i2c = I2c::new_blocking(p.I2C1, scl, sda, Hertz::hz(400_000), Default::default());
+    let i2c = I2c::new(
+        p.I2C1,
+        scl,
+        sda,
+        Irqs,
+        p.DMA1_CH6,
+        p.DMA1_CH7,
+        Hertz::hz(400_000),
+        Default::default(),
+    );
 
-    // let mut bus: Mutex<NoopRawMutex, _> = Mutex::new(i2c);
-    // let bus: I2cBus = ;
-    static I2C_BUS: StaticCell<I2cBus> = StaticCell::new();
-    let i2c_bus: &'static I2cBus = I2C_BUS.init(Mutex::new(i2c));
-    spawner.spawn(i2c_task_one(&i2c_bus)).unwrap();
-    // let display_i2c_dev = I2cDevice::new(&bus);
+    //sets up a i2c bus using the custom type I2cBus at the top
+    let i2c_bus: I2cBus = Mutex::new(i2c);
+
+    //Sets up 2 difference embedded_hal devices from the i2c bus
+    let i2c_device_1 = I2cDevice::new(&i2c_bus);
+    let i2c_device_2 = I2cDevice::new(&i2c_bus);
+
+    //Sets up 2 dummy i2c drivers one for each device
+    let mut _dummy_i2c_driver_1 = DummyI2cDeviceDriver::new(i2c_device_1, 0x01);
+    let mut _dummy_i2c_driver_2 = DummyI2cDeviceDriver::new(i2c_device_2, 0x02);
+
     loop {
+        led.toggle();
+        println!("toggle!");
         Timer::after_millis(1000).await;
     }
 }
 
-/// Well this compiles?
-#[embassy_executor::task]
-async fn i2c_task_one(i2c_bus: &'static I2cBus) {}
+// Dummy I2C device driver, using `embedded-hal-async`
+struct DummyI2cDeviceDriver<I2C: embedded_hal_async::i2c::I2c> {
+    _i2c: I2C,
+}
+
+impl<I2C: embedded_hal_async::i2c::I2c> DummyI2cDeviceDriver<I2C> {
+    fn new(i2c_dev: I2C, _address: u8) -> Self {
+        Self { _i2c: i2c_dev }
+    }
+}

--- a/examples/ch32v003/src/bin/embassy_i2c_shared_bus.rs
+++ b/examples/ch32v003/src/bin/embassy_i2c_shared_bus.rs
@@ -1,0 +1,44 @@
+//! This example shows how to share (async) I2C buses between multiple devices with embassy.
+
+#![no_std]
+#![no_main]
+
+use ch32_hal::gpio::{Level, Output};
+use ch32_hal::i2c::I2c;
+use ch32_hal::mode::Blocking;
+// use ch32_hal::pac::I2C1;
+use ch32_hal::time::Hertz;
+use embassy_embedded_hal::shared_bus::blocking::i2c::I2cDevice;
+use embassy_executor::Spawner;
+use embassy_sync::blocking_mutex::{Mutex, NoopMutex};
+use embassy_time::Timer;
+use panic_halt as _;
+use static_cell::StaticCell;
+
+type I2cBus = NoopMutex<I2c<'static, ch32_hal::peripherals::I2C1, Blocking>>;
+
+#[embassy_executor::main(entry = "qingke_rt::entry")]
+async fn main(spawner: Spawner) -> ! {
+    ch32_hal::debug::SDIPrint::enable();
+    let p = ch32_hal::init(ch32_hal::Config::default());
+    let mut led = Output::new(p.PD6, Level::Low, Default::default());
+
+    led.set_high();
+    let scl = p.PC2;
+    let sda = p.PC1;
+    let i2c = I2c::new_blocking(p.I2C1, scl, sda, Hertz::hz(400_000), Default::default());
+
+    // let mut bus: Mutex<NoopRawMutex, _> = Mutex::new(i2c);
+    // let bus: I2cBus = ;
+    static I2C_BUS: StaticCell<I2cBus> = StaticCell::new();
+    let i2c_bus: &'static I2cBus = I2C_BUS.init(Mutex::new(i2c));
+    spawner.spawn(i2c_task_one(&i2c_bus)).unwrap();
+    // let display_i2c_dev = I2cDevice::new(&bus);
+    loop {
+        Timer::after_millis(1000).await;
+    }
+}
+
+/// Well this compiles?
+#[embassy_executor::task]
+async fn i2c_task_one(i2c_bus: &'static I2cBus) {}


### PR DESCRIPTION
I've been enjoying this crate and trying out this little microcontroller with Rust. While testing it out and seeing what it could do with a little demo project, I needed 2 i2c devices and came up with this solution that works, as shown in the video. The demo reads from an SCD40 sensor, then displays it to an OLED SSD1306  and bounces like a DVD logo.  I'm unsure if it really counts as a bus, but it works for me. 

A couple of things on it
* I based this example off of [embassy's rp example](https://github.com/embassy-rs/embassy/blob/main/examples/rp/src/bin/shared_bus.rs). I used a dummy device as they did, but I can also change it to use an actual crate if preferred
* I did try to break this out into tasks and did get it to build with StaticCell version 1.3 and blocking i2c. But the minute it passed the i2c bus to another task it would panic and have not been able to get panic messages to print on the ch32v003. 



https://github.com/user-attachments/assets/69a9290c-d462-4dc0-8d4d-ccfad4a5ab45





