### PR TITLE
ch32v003 examples: pin qingke-rt to version 0.5.0

### DIFF
--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -21,7 +21,7 @@ embassy-time = { version = "0.3.0" }
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "*"
-qingke-rt = { version = "*", features = ["highcode"] }
+qingke-rt = { version = "0.5.0", features=["highcode"] }
 
 
 panic-halt = "1.0"


### PR DESCRIPTION
the previous version selected by cargo with "*" (0.2.0) caused the build to break with an error failed to load bitcode of module "qingke-c4359a58ea77d2f5.qingke.ea2e92fc367b3625-cgu.0.rcgu.o"