### PR TITLE
ch32v003 embassy example: double task arena size

### DIFF
--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -15,7 +15,7 @@ embassy-executor = { version = "0.6.0", features = [
     "integrated-timers",
     "arch-spin",
     "executor-thread",
-    "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
+    "task-arena-size-256", # or better use nightly, but fails on recent Rust versions
 ] }
 embassy-time = { version = "0.3.0" }
 


### PR DESCRIPTION
without this, the embassy example will not compile with rust-nightly, the compiler will complain about a too small task arena size. Since the example is rather small however, there is no problem in doubling the task arena size, as it will not consume too much memory overall.