### PR TITLE
examples: change all clocks for ch32v003 to use internal oscillator by default

### DIFF
--- a/examples/ch32v003/src/bin/adc.rs
+++ b/examples/ch32v003/src/bin/adc.rs
@@ -12,7 +12,7 @@ use {ch32_hal as hal, panic_halt as _};
 fn main() -> ! {
     hal::debug::SDIPrint::enable();
     let mut config = hal::Config::default();
-    config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSE;
+    config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSI;
     let p = hal::init(config);
 
     let mut delay = Delay;

--- a/examples/ch32v003/src/bin/blinky.rs
+++ b/examples/ch32v003/src/bin/blinky.rs
@@ -11,7 +11,7 @@ use {ch32_hal as hal, panic_halt as _};
 fn main() -> ! {
     hal::debug::SDIPrint::enable();
     let mut config = hal::Config::default();
-    config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSE;
+    config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSI;
     let p = hal::init(config);
 
     let mut delay = Delay;

--- a/examples/ch32v003/src/bin/pwm.rs
+++ b/examples/ch32v003/src/bin/pwm.rs
@@ -12,7 +12,9 @@ use {ch32_hal as hal, panic_halt as _};
 #[qingke_rt::entry]
 fn main() -> ! {
     hal::debug::SDIPrint::enable();
-    let p = hal::init(Default::default());
+    let mut config = hal::Config::default();
+    config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSI;
+    let p = hal::init(config);
 
     let pin = PwmPin::new_ch4::<0>(p.PC4);
     let mut pwm = SimplePwm::new(

--- a/examples/ch32v003/src/bin/spi-lcd-st7735-cube.rs
+++ b/examples/ch32v003/src/bin/spi-lcd-st7735-cube.rs
@@ -238,9 +238,10 @@ impl<const WIDTH: u16, const HEIGHT: u16, const OFFSETX: u16, const OFFSETY: u16
 fn main() -> ! {
     hal::debug::SDIPrint::enable();
     let mut config = hal::Config::default();
-    config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSE;
+    config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSI;
     let p = hal::init(config);
 
+    hal::println!("spi-lcd-st7335-cube example starting");
 
     // SPI1, remap 0
     let cs = p.PC1;

--- a/examples/ch32v003/src/bin/uart_tx.rs
+++ b/examples/ch32v003/src/bin/uart_tx.rs
@@ -13,7 +13,7 @@ use {ch32_hal as hal, panic_halt as _};
 fn main() -> ! {
     hal::debug::SDIPrint::enable();
     let mut config = hal::Config::default();
-    config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSE;
+    config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSI;
     let p = hal::init(config);
 
     let mut uart = UartTx::new_blocking(p.USART1, p.PC0, Default::default()).unwrap();


### PR DESCRIPTION
Some examples for ch32v003 use `SYSCLK_FREQ_48MHZ_HSE` as their clock source which prevents them from working on any board that does not have the external oscillator installed. 

I changed all examples to use  `SYSCLK_FREQ_48MHZ_HSI` and added explicit clock initialisation in `pwm` example. Now the examples should work on any ch32v003 board.