### PR TITLE
Add 10M MAC+PHY for the CH32V208

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ embassy-time-queue-utils = { version = "0.3.0", optional = true }
 embassy-time-driver = { version = "0.2.0", optional = true }
 embassy-time = { version = "0.5.0", optional = true }
 embassy-usb-driver = "0.2.0"
+embassy-net-driver = "0.2.0"
+embassy-net-driver-channel = "0.4.0"
 embassy-hal-internal = "0.3.0"
 
 nb = "1.1.0"

--- a/examples/ch32v208/Cargo.toml
+++ b/examples/ch32v208/Cargo.toml
@@ -23,6 +23,15 @@ qingke = "0.7"
 panic-halt = "1.0"
 embedded-storage = "0.3.1"
 
+embassy-net = { version = "0.8.0", features = ["tcp", "udp", "dhcpv4", "medium-ethernet", "proto-ipv4"] }
+embassy-net-driver = "0.2.0"
+static_cell = "2.1"
+embedded-io-async = "0.7"
+portable-atomic = { version = "1", features = ["critical-section"] }
+
+embassy-futures = "0.1.1"
+heapless = "0.8.0"
+
 [profile.release]
 strip = false   # symbols are not flashed to the microcontroller, so don't strip them.
 lto = true

--- a/examples/ch32v208/src/bin/eth.rs
+++ b/examples/ch32v208/src/bin/eth.rs
@@ -1,0 +1,102 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_net::udp::{PacketMetadata, UdpSocket};
+use embassy_net::StackResources;
+use embassy_time::{Duration, Timer};
+use hal::eth::generic_smi::GenericSMI;
+use hal::rcc::*;
+use hal::time::Hertz;
+use hal::{eth, interrupt, println};
+use static_cell::StaticCell;
+use {ch32_hal as hal, panic_halt as _};
+
+#[embassy_executor::task]
+async fn net_task(mut runner: embassy_net::Runner<'static, eth::Device<'static>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn ethernet_task(runner: eth::Runner<'static, GenericSMI>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::main(entry = "ch32_hal::entry")]
+async fn main(spawner: Spawner) -> ! {
+    // Configure core speed at 60MHz (16MHz HSE * 15 / 4 = 60MHz)
+    let _p = ch32_hal::init(ch32_hal::Config {
+        rcc: ch32_hal::rcc::Config {
+            hse: Some(Hse {
+                freq: Hertz(16_000_000),
+                mode: HseMode::Oscillator,
+            }),
+            sys: Sysclk::PLL,
+            pll_src: PllSource::HSE,
+            pll: Some(Pll {
+                prediv: PllPreDiv::DIV4,
+                mul: PllMul::MUL15,
+            }),
+            pllx: None,
+            ahb_pre: AHBPrescaler::DIV1,
+            apb1_pre: APBPrescaler::DIV1,
+            apb2_pre: APBPrescaler::DIV1,
+            ls: LsConfig::default(),
+            hspll_src: HsPllSource::HSI,
+            hspll: None,
+        },
+        dma_interrupt_priority: interrupt::Priority::P0,
+    });
+    let core_freq: u32 = 60_000_000;
+
+    ch32_hal::debug::SDIPrint::enable();
+    Timer::after(Duration::from_millis(100)).await;
+    println!("Hello CH32!");
+
+    // Ethernet setup
+    let mac_addr = eth::get_mac();
+    println!("mac_addr: {mac_addr:?}");
+
+    let phy = GenericSMI::new(0);
+    static STATE: StaticCell<eth::State<2, 2>> = StaticCell::new();
+    let state = STATE.init(eth::State::new());
+    let (runner, device) = eth::new(mac_addr, core_freq, phy, state).await.unwrap();
+    println!("device: done");
+
+    // Generate random seed
+    let seed = 0xdeadbeef_abadbabe;
+
+    // Init network stack
+    static RESOURCES: StaticCell<StackResources<2>> = StaticCell::new();
+    let config = embassy_net::Config::dhcpv4(Default::default());
+    let (stack, net_runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
+
+    spawner.spawn(ethernet_task(runner)).unwrap();
+    spawner.spawn(net_task(net_runner)).unwrap();
+
+    println!("Waiting for DHCP...");
+    stack.wait_config_up().await;
+
+    if let Some(config) = stack.config_v4() {
+        println!("IP address: {}", config.address);
+    }
+
+    // UDP echo server on port 1234
+    let mut rx_buffer = [0; 300];
+    let mut tx_buffer = [0; 300];
+    let mut rx_meta = [PacketMetadata::EMPTY; 16];
+    let mut tx_meta = [PacketMetadata::EMPTY; 16];
+    let mut buf = [0; 300];
+    loop {
+        let mut socket = UdpSocket::new(stack, &mut rx_meta, &mut rx_buffer, &mut tx_meta, &mut tx_buffer);
+        socket.bind(1234).unwrap();
+
+        loop {
+            let (n, ep) = socket.recv_from(&mut buf).await.unwrap();
+            if let Ok(s) = core::str::from_utf8(&buf[..n]) {
+                println!("rxd from {}: {}", ep, s);
+            }
+            socket.send_to(&buf[..n], ep).await.unwrap();
+        }
+    }
+}

--- a/examples/ch32v208/src/bin/eth_echo.rs
+++ b/examples/ch32v208/src/bin/eth_echo.rs
@@ -1,0 +1,128 @@
+//! Ethernet TCP echo server for CH32V208 (built-in 10M PHY).
+//!
+//! Initializes the CH32V208's built-in 10M Ethernet MAC+PHY,
+//! obtains an IP via DHCP, and runs a TCP echo server on port 1234.
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_net::tcp::TcpSocket;
+use embassy_net::StackResources;
+use embassy_time::{Duration, Timer};
+use embedded_io_async::Write;
+use hal::eth::generic_smi::GenericSMI;
+use hal::rcc::*;
+use hal::time::Hertz;
+use hal::{eth, interrupt, println};
+use static_cell::StaticCell;
+use {ch32_hal as hal, panic_halt as _};
+
+#[embassy_executor::task]
+async fn net_task(mut runner: embassy_net::Runner<'static, eth::Device<'static>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn ethernet_task(runner: eth::Runner<'static, GenericSMI>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::main(entry = "ch32_hal::entry")]
+async fn main(spawner: Spawner) -> ! {
+    // Configure core speed at 60MHz (16MHz HSE * 15 / 4 = 60MHz)
+    let _p = ch32_hal::init(ch32_hal::Config {
+        rcc: ch32_hal::rcc::Config {
+            hse: Some(Hse {
+                freq: Hertz(16_000_000),
+                mode: HseMode::Oscillator,
+            }),
+            sys: Sysclk::PLL,
+            pll_src: PllSource::HSE,
+            pll: Some(Pll {
+                prediv: PllPreDiv::DIV4,
+                mul: PllMul::MUL15,
+            }),
+            pllx: None,
+            ahb_pre: AHBPrescaler::DIV1,
+            apb1_pre: APBPrescaler::DIV1,
+            apb2_pre: APBPrescaler::DIV1,
+            ls: LsConfig::default(),
+            hspll_src: HsPllSource::HSI,
+            hspll: None,
+        },
+        dma_interrupt_priority: interrupt::Priority::P0,
+    });
+    let core_freq: u32 = 60_000_000;
+
+    ch32_hal::debug::SDIPrint::enable();
+    Timer::after(Duration::from_millis(100)).await;
+    println!("Hello CH32 - TCP echo server!");
+
+    // Ethernet setup
+    let mac_addr = eth::get_mac();
+    println!("mac_addr: {mac_addr:?}");
+
+    let phy = GenericSMI::new(0);
+    static STATE: StaticCell<eth::State<2, 2>> = StaticCell::new();
+    let state = STATE.init(eth::State::new());
+    let (runner, device) = eth::new(mac_addr, core_freq, phy, state).await.unwrap();
+    println!("device: done");
+
+    // Generate random seed
+    let seed = 0x1234_5678_9abc_def0u64;
+
+    // Init network stack
+    static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+    let config = embassy_net::Config::dhcpv4(Default::default());
+    let (stack, net_runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
+
+    spawner.spawn(ethernet_task(runner)).unwrap();
+    spawner.spawn(net_task(net_runner)).unwrap();
+
+    println!("Waiting for DHCP...");
+    stack.wait_config_up().await;
+
+    if let Some(config) = stack.config_v4() {
+        println!("IP address: {}", config.address);
+    }
+
+    // TCP echo server on port 1234
+    let mut rx_buffer = [0u8; 1024];
+    let mut tx_buffer = [0u8; 1024];
+    let mut buf = [0u8; 512];
+
+    loop {
+        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        socket.set_timeout(Some(Duration::from_secs(30)));
+
+        println!("Listening on TCP port 1234...");
+
+        if let Err(e) = socket.accept(1234).await {
+            println!("Accept error: {:?}", e);
+            Timer::after_secs(1).await;
+            continue;
+        }
+
+        println!("Client connected!");
+
+        loop {
+            let n = match socket.read(&mut buf).await {
+                Ok(0) => {
+                    println!("Client disconnected");
+                    break;
+                }
+                Ok(n) => n,
+                Err(e) => {
+                    println!("Read error: {:?}", e);
+                    break;
+                }
+            };
+
+            if let Err(e) = socket.write_all(&buf[..n]).await {
+                println!("Write error: {:?}", e);
+                break;
+            }
+        }
+    }
+}

--- a/src/eth/generic_smi.rs
+++ b/src/eth/generic_smi.rs
@@ -62,12 +62,6 @@ unsafe impl PHY for GenericSMI {
 
 /// Public functions for the PHY
 impl GenericSMI {
-    /// Set the SMI polling interval.
-    #[cfg(feature = "time")]
-    pub fn set_poll_interval(&mut self, poll_interval: Duration) {
-        self.poll_interval = poll_interval
-    }
-
     // Writes a value to an extended PHY register in MMD address space
     pub fn smi_write_ext<S: StationManagement>(&mut self, sm: &mut S, reg_addr: u16, reg_data: u16) {
         sm.smi_write(self.phy_addr, PHY_REG_CTL, 0x0003); // set address

--- a/src/eth/generic_smi.rs
+++ b/src/eth/generic_smi.rs
@@ -1,0 +1,78 @@
+//! Generic SMI Ethernet PHY
+
+use super::{StationManagement, PHY};
+
+#[allow(dead_code)]
+mod phy_consts {
+    pub const PHY_REG_BCR: u8 = 0x00;
+    pub const PHY_REG_BSR: u8 = 0x01;
+    pub const PHY_REG_ID1: u8 = 0x02;
+    pub const PHY_REG_ID2: u8 = 0x03;
+    pub const PHY_REG_ANTX: u8 = 0x04;
+    pub const PHY_REG_ANRX: u8 = 0x05;
+    pub const PHY_REG_ANEXP: u8 = 0x06;
+    pub const PHY_REG_ANNPTX: u8 = 0x07;
+    pub const PHY_REG_ANNPRX: u8 = 0x08;
+    pub const PHY_REG_CTL: u8 = 0x0D; // Ethernet PHY Register Control
+    pub const PHY_REG_ADDAR: u8 = 0x0E; // Ethernet PHY Address or Data
+
+    pub const PHY_REG_WUCSR: u16 = 0x8010;
+
+    pub const PHY_REG_BCR_COLTEST: u16 = 1 << 7;
+    pub const PHY_REG_BCR_FD: u16 = 1 << 8;
+    pub const PHY_REG_BCR_ANRST: u16 = 1 << 9;
+    pub const PHY_REG_BCR_ISOLATE: u16 = 1 << 10;
+    pub const PHY_REG_BCR_POWERDN: u16 = 1 << 11;
+    pub const PHY_REG_BCR_AN: u16 = 1 << 12;
+    pub const PHY_REG_BCR_100M: u16 = 1 << 13;
+    pub const PHY_REG_BCR_LOOPBACK: u16 = 1 << 14;
+    pub const PHY_REG_BCR_RESET: u16 = 1 << 15;
+
+    pub const PHY_REG_BSR_JABBER: u16 = 1 << 1;
+    pub const PHY_REG_BSR_UP: u16 = 1 << 2;
+    pub const PHY_REG_BSR_FAULT: u16 = 1 << 4;
+    pub const PHY_REG_BSR_ANDONE: u16 = 1 << 5;
+}
+use self::phy_consts::*;
+
+/// Generic SMI Ethernet PHY implementation
+pub struct GenericSMI {
+    phy_addr: u8,
+}
+
+impl GenericSMI {
+    /// Construct the PHY. It assumes the address `phy_addr` in the SMI communication
+    pub fn new(phy_addr: u8) -> Self {
+        Self { phy_addr }
+    }
+}
+
+unsafe impl PHY for GenericSMI {
+    fn phy_reset<S: StationManagement>(&mut self, sm: &mut S) {
+        sm.smi_write(self.phy_addr, PHY_REG_BCR, PHY_REG_BCR_RESET);
+        while sm.smi_read(self.phy_addr, PHY_REG_BCR) & PHY_REG_BCR_RESET == PHY_REG_BCR_RESET {}
+    }
+
+    fn link_up<S: StationManagement>(&mut self, sm: &mut S) -> bool {
+        let bsr = sm.smi_read(self.phy_addr, PHY_REG_BSR);
+
+        bsr & PHY_REG_BSR_UP != 0
+    }
+}
+
+/// Public functions for the PHY
+impl GenericSMI {
+    /// Set the SMI polling interval.
+    #[cfg(feature = "time")]
+    pub fn set_poll_interval(&mut self, poll_interval: Duration) {
+        self.poll_interval = poll_interval
+    }
+
+    // Writes a value to an extended PHY register in MMD address space
+    pub fn smi_write_ext<S: StationManagement>(&mut self, sm: &mut S, reg_addr: u16, reg_data: u16) {
+        sm.smi_write(self.phy_addr, PHY_REG_CTL, 0x0003); // set address
+        sm.smi_write(self.phy_addr, PHY_REG_ADDAR, reg_addr);
+        sm.smi_write(self.phy_addr, PHY_REG_CTL, 0x4003); // set data
+        sm.smi_write(self.phy_addr, PHY_REG_ADDAR, reg_data);
+    }
+}

--- a/src/eth/mod.rs
+++ b/src/eth/mod.rs
@@ -1,0 +1,52 @@
+//! Ethernet (ETH)
+#![macro_use]
+
+#[cfg_attr(eth_10m, path = "v10m/mod.rs")]
+#[cfg_attr(eth_v1, path = "v1/mod.rs")]
+mod _version;
+
+pub mod generic_smi;
+
+pub use self::_version::*;
+
+#[allow(unused)]
+const MTU: usize = 1514;
+
+/// Station Management Interface (SMI) on an ethernet PHY
+///
+/// # Safety
+///
+/// The methods cannot move out of self
+pub unsafe trait StationManagement {
+    /// Read a register over SMI.
+    fn smi_read(&mut self, phy_addr: u8, reg: u8) -> u16;
+    /// Write a register over SMI.
+    fn smi_write(&mut self, phy_addr: u8, reg: u8, val: u16);
+}
+
+/// Traits for an Ethernet PHY
+///
+/// # Safety
+///
+/// The methods cannot move S
+pub unsafe trait PHY {
+    /// Reset PHY and wait for it to come out of reset.
+    fn phy_reset<S: StationManagement>(&mut self, sm: &mut S);
+    /// Read PHY registers to check if link is established
+    fn link_up<S: StationManagement>(&mut self, sm: &mut S) -> bool;
+}
+
+trait SealedInstance {
+    fn regs() -> crate::pac::eth::Eth;
+}
+
+/// Ethernet instance.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + Send + 'static {}
+
+impl SealedInstance for crate::peripherals::ETH {
+    fn regs() -> crate::pac::eth::Eth {
+        crate::pac::ETH
+    }
+}
+impl Instance for crate::peripherals::ETH {}

--- a/src/eth/v10m/mod.rs
+++ b/src/eth/v10m/mod.rs
@@ -1,0 +1,344 @@
+//! Ethernet MAC+PHY driver for CH32V208 (10M PHY).
+//!
+//! This module provides an embassy-net compatible driver for the built-in 10M Ethernet MAC+PHY
+//! found on CH32V208 microcontrollers. The CH32V208 uses an ENC28J60-inspired register set
+//! with register-based buffer management (no DMA descriptors).
+//!
+//! Uses `embassy-net-driver-channel` to provide multi-buffer RX/TX queues,
+//! so packets are not lost while the CPU is processing.
+
+use core::marker::PhantomData;
+use core::sync::atomic::{fence, Ordering};
+
+use embassy_net_driver::LinkState;
+use embassy_net_driver_channel as ch;
+use embassy_sync::channel::Channel;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_time::Timer;
+
+use crate::eth::{Instance, StationManagement, PHY};
+use crate::interrupt;
+
+const MTU: usize = 1514;
+
+/// The `embassy-net` device type for the CH32V208 10M Ethernet driver.
+pub type Device<'d> = ch::Device<'d, MTU>;
+
+/// Buffer state for the channel driver.
+///
+/// `N_RX` and `N_TX` set the number of RX/TX packet buffers.
+/// More buffers improve throughput at the cost of RAM.
+pub struct State<const N_RX: usize, const N_TX: usize> {
+    ch_state: ch::State<MTU, N_RX, N_TX>,
+}
+
+impl<const N_RX: usize, const N_TX: usize> State<N_RX, N_TX> {
+    /// Create a new buffer state.
+    pub const fn new() -> Self {
+        Self {
+            ch_state: ch::State::new(),
+        }
+    }
+}
+
+/// ISR → Runner communication channels.
+///
+/// Using embassy_sync Channels instead of bare flags so the Runner
+/// can `.recv().await` without busy-polling.
+static RX_CH: Channel<CriticalSectionRawMutex, u16, 1> = Channel::new();
+static TX_CH: Channel<CriticalSectionRawMutex, (), 2> = Channel::new();
+static LINK_CH: Channel<CriticalSectionRawMutex, (), 2> = Channel::new();
+
+#[interrupt]
+unsafe fn ETH() {
+    let mac = crate::pac::ETH;
+
+    // Disable global interrupt while processing
+    mac.eie().modify(|w| w.set_intie(false));
+    fence(Ordering::SeqCst);
+
+    let flags = mac.eir().read();
+    // Clear handled flags (write-1-to-clear)
+    mac.eir().write_value(flags);
+
+    if flags.rxif() {
+        let len = mac.erxln().read().erxln();
+        // Try to send; if full, packet is dropped (better than blocking in ISR)
+        let _ = RX_CH.try_send(len);
+    }
+
+    if flags.txif() {
+        let _ = TX_CH.try_send(());
+    }
+
+    if flags.linkif() {
+        let _ = LINK_CH.try_send(());
+    }
+
+    fence(Ordering::SeqCst);
+    mac.eie().modify(|w| w.set_intie(true));
+}
+
+/// Error type for ethernet initialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InitError {
+    /// The core frequency must be 60MHz or 120MHz.
+    CoreFrequencyInvalid,
+}
+
+/// The async runner that drives the ethernet hardware.
+///
+/// Must be spawned as a separate embassy task via [`Runner::run()`].
+pub struct Runner<'d, P: PHY> {
+    mac: crate::pac::eth::Eth,
+    phy: P,
+    ch: ch::Runner<'d, MTU>,
+    station_management: EthernetStationManagement<crate::peripherals::ETH>,
+}
+
+impl<'d, P: PHY> Runner<'d, P> {
+    /// Run the ethernet driver forever.
+    ///
+    /// This handles RX, TX, and link state monitoring concurrently.
+    pub async fn run(self) -> ! {
+        let mac = self.mac;
+        let mut phy = self.phy;
+        let mut station_management = self.station_management;
+        let (state_chan, mut rx_chan, mut tx_chan) = self.ch.split();
+
+        // Drain any stale signals
+        while RX_CH.try_receive().is_ok() {}
+        while TX_CH.try_receive().is_ok() {}
+        while LINK_CH.try_receive().is_ok() {}
+
+        let rx_fut = async {
+            loop {
+                // Get a buffer from the channel to receive into
+                let buf = rx_chan.rx_buf().await;
+
+                // Point hardware at this buffer and enable reception
+                mac.mamxfl().write(|w| w.set_mamxfl(buf.len() as u16));
+                mac.erxst().write(|w| w.set_erxst(buf.as_ptr() as u16));
+                mac.macon1().write(|w| w.set_marxen(true));
+                mac.econ1().modify(|w| {
+                    w.set_rx_en(true);
+                });
+
+                // Wait for RX interrupt - len comes from the ISR
+                let len = RX_CH.receive().await as usize;
+                let len = len.min(buf.len());
+
+                // Tell the channel we received `len` bytes
+                rx_chan.rx_done(len);
+            }
+        };
+
+        let tx_fut = async {
+            loop {
+                // Get a buffer with data to transmit
+                let buf = tx_chan.tx_buf().await;
+                let len = buf.len();
+
+                // Point hardware at this buffer
+                mac.etxst().write(|w| w.set_etxst(buf.as_ptr() as u16));
+                mac.etxln().write(|w| w.set_etxln(len as u16));
+
+                // Trigger transmission
+                mac.econ1().modify(|w| {
+                    w.set_tx_rts(true);
+                });
+
+                // Wait for TX complete interrupt
+                TX_CH.receive().await;
+
+                // Tell the channel we're done with this buffer
+                tx_chan.tx_done();
+            }
+        };
+
+        let link_fut = async {
+            loop {
+                let up = phy.link_up(&mut station_management);
+                state_chan.set_link_state(if up {
+                    LinkState::Up
+                } else {
+                    LinkState::Down
+                });
+
+                // Wait for link change interrupt or poll periodically
+                embassy_futures::select::select(
+                    LINK_CH.receive(),
+                    Timer::after_millis(500),
+                )
+                .await;
+            }
+        };
+
+        embassy_futures::join::join3(rx_fut, tx_fut, link_fut).await;
+        unreachable!()
+    }
+}
+
+/// Get the factory-programmed MAC address from chip UID.
+///
+/// Each CH32 comes with a unique ID that can be used as MAC address.
+/// This reads the 6 bytes from flash and returns them in wire order.
+pub fn get_mac() -> [u8; 6] {
+    const ADDRESS: *const u8 = (0x1FFFF7E8 + 5) as *const u8;
+    let mut mac = [0u8; 6];
+    unsafe {
+        let mac_bytes: &[u8] = core::slice::from_raw_parts(ADDRESS, 6);
+        mac.copy_from_slice(mac_bytes);
+        mac.reverse();
+    };
+    // Clear multicast bit (LSB of first octet) for unicast
+    mac[0] &= 0xFE;
+    mac
+}
+
+/// Create a CH32V208 10M MAC+PHY driver for [`embassy-net`](https://crates.io/crates/embassy-net).
+///
+/// Returns a `(Runner, Device)` pair. The `Device` is passed to `embassy_net::new()`,
+/// and the `Runner` must be spawned as a separate embassy task.
+///
+/// # Arguments
+/// * `mac_addr` - The MAC address for this device (6 bytes)
+/// * `core_freq` - Core clock frequency in Hz (must be 60MHz or 120MHz)
+/// * `phy` - A PHY driver instance (e.g. `GenericSMI::new(0)`)
+/// * `state` - A `&'static mut State<N_RX, N_TX>` providing packet buffers
+pub async fn new<'d, P: PHY, const N_RX: usize, const N_TX: usize>(
+    mac_addr: [u8; 6],
+    core_freq: u32,
+    phy: P,
+    state: &'d mut State<N_RX, N_TX>,
+) -> Result<(Runner<'d, P>, Device<'d>), InitError> {
+    let mac = crate::pac::ETH;
+    let extend = crate::pac::EXTEND;
+    let rcc = crate::pac::RCC;
+
+    // Configure ETH clock prescaler
+    if core_freq == 60_000_000 {
+        rcc.cfgr0()
+            .modify(|w| w.set_ethpre(crate::pac::rcc::vals::Ethpre::DIV1));
+    } else if core_freq == 120_000_000 {
+        rcc.cfgr0()
+            .modify(|w| w.set_ethpre(crate::pac::rcc::vals::Ethpre::DIV2));
+    } else {
+        return Err(InitError::CoreFrequencyInvalid);
+    }
+
+    // Enable built-in 10M PHY clock
+    extend.ctr().modify(|w| w.set_eth_10m_en(true));
+
+    // Reset RX and TX paths
+    mac.econ1().write(|w| {
+        w.set_rx_rst(true);
+        w.set_tx_rst(true);
+    });
+    Timer::after_micros(1).await;
+
+    // Release reset
+    mac.econ1().write(|_w| {});
+    Timer::after_micros(1).await;
+
+    // Clear all interrupt flags
+    mac.eir().write(|w| w.0 = 0xff);
+
+    // Configure transmitter
+    mac.econ2().write(|w| {
+        w.set_tx(false); // enable transmitter (active low)
+        w.set_rx_must(0b110); // reserved value, must be written 0b110
+    });
+
+    // Configure MAC layer
+    mac.macon2().modify(|w| {
+        w.set_padcfg(0b001); // pad short packets to 64 bytes
+        w.set_txcrcen(true); // append CRC
+        w.set_fuldpx(true); // full duplex
+    });
+
+    // Configure receive filter
+    mac.erxfcon().write(|w| {
+        w.set_en(false); // disable receive filtering
+        w.set_bcen(true); // receive broadcast
+        w.set_hten(true); // hash table filter
+        w.set_mcen(true); // receive multicast
+        w.set_mpen(true); // magic packet
+        w.set_ucen(true); // unicast matching MAC
+        w.set_crcen(true); // CRC check
+    });
+
+    // Configure and enable interrupts
+    mac.eie().write(|w| {
+        w.set_intie(true); // global interrupt enable
+        w.set_rxie(true); // receive interrupt
+        w.set_linkie(true); // link change interrupt
+        w.set_txie(true); // transmit done interrupt
+        w.set_r_en50(true); // enable 50 Ohm termination resistor on RX
+    });
+
+    // Set MAC address (register order: maadr0 = byte 5, maadr5 = byte 0)
+    mac.maadr0().write(|w| w.set_maadr(mac_addr[5]));
+    mac.maadr1().write(|w| w.set_maadr(mac_addr[4]));
+    mac.maadr2().write(|w| w.set_maadr(mac_addr[3]));
+    mac.maadr3().write(|w| w.set_maadr(mac_addr[2]));
+    mac.maadr4().write(|w| w.set_maadr(mac_addr[1]));
+    mac.maadr5().write(|w| w.set_maadr(mac_addr[0]));
+
+    fence(Ordering::SeqCst);
+
+    // Enable ETH interrupt in PFIC
+    unsafe {
+        qingke::pfic::enable_interrupt(crate::pac::Interrupt::ETH as u8);
+    };
+
+    let station_management = EthernetStationManagement::<crate::peripherals::ETH>::new();
+
+    // Create the channel-based driver
+    let (runner, device) = ch::new(
+        &mut state.ch_state,
+        embassy_net_driver::HardwareAddress::Ethernet(mac_addr),
+    );
+
+    Ok((
+        Runner {
+            mac,
+            phy,
+            ch: runner,
+            station_management,
+        },
+        device,
+    ))
+}
+
+/// Ethernet station management (SMI/MDIO) driver.
+struct EthernetStationManagement<T: Instance> {
+    _peri: PhantomData<T>,
+}
+
+impl<T: Instance> EthernetStationManagement<T> {
+    pub fn new() -> Self {
+        Self { _peri: PhantomData }
+    }
+}
+
+unsafe impl<T: Instance> StationManagement for EthernetStationManagement<T> {
+    fn smi_read(&mut self, _phy_addr: u8, reg: u8) -> u16 {
+        let mac = T::regs();
+
+        mac.miregadr().write(|w| {
+            w.set_miregadr(reg & 0x1F);
+        });
+        mac.mird().read().rd()
+    }
+
+    fn smi_write(&mut self, _phy_addr: u8, reg: u8, val: u16) {
+        let mac = T::regs();
+
+        mac.miwr().write(|w| {
+            w.set_write(true);
+            w.set_mirdl(reg & 0x1F);
+            w.set_wr(val);
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,8 @@ pub mod usbhs;
 #[cfg(usbpd)]
 pub mod usbpd;
 
+#[cfg(eth)]
+pub mod eth;
 #[cfg(can)]
 pub mod can;
 


### PR DESCRIPTION
The CH32V208 has a MAC that's unique to itself, but relatively simple.
I was able to make the demo work on some custom HW of mine.

While this is functional, it's not the 'cleanest' implementation.
Feedback welcome.

This PR depends on https://github.com/ch32-rs/ch32-data/pull/16 for the registers definitions.
Once merged, the dependency yo ch3é-metapac should be updated here.


Note: This is incompatible with the MAC inside the CH32V30x.
While there is no support for the CH32V30x MAC, the basic infrastructure to include the correct ETH driver is present.
Also, the CH32V30x has a MAC that's very close to STM32's 'v1a' so [embassy-stm32](https://github.com/embassy-rs/embassy/tree/main/embassy-stm32/src/eth/v1) should be a good starting point for future work.
