### PR TITLE
Switched to embassy_time 0.4.0 and embassy_executor 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ defmt = { version = "0.3.8", optional = true }
 
 embassy-sync = { version = "0.6.0" }
 embassy-futures = { version = "0.1.1" }
-embassy-time-driver = { version = "0.1.0", optional = true }
-embassy-time = { version = "0.3.2", optional = true }
+embassy-time-driver = { version = "0.2.0", optional = true }
+embassy-time = { version = "0.4.0", optional = true }
 embassy-usb-driver = "0.1.0"
 
 nb = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ defmt = { version = "0.3.8", optional = true }
 
 embassy-sync = { version = "0.6.0" }
 embassy-futures = { version = "0.1.1" }
+embassy-time-queue-utils = { version = "0.1", optional = true }
 embassy-time-driver = { version = "0.2.0", optional = true }
 embassy-time = { version = "0.4.0", optional = true }
 embassy-usb-driver = "0.1.0"
@@ -59,6 +60,7 @@ default = ["embassy", "rt"]
 rt = ["dep:qingke-rt"]
 highcode = ["qingke-rt/highcode"]
 embassy = [
+    "dep:embassy-time-queue-utils",
     "dep:embassy-time-driver",
     "dep:embassy-time",
 ]

--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ For a full list of chip capabilities and peripherals, check the [ch32-data](http
 
 ### Notes
 - For USB OTGFS and HS, look at the `mod.rs` respsectively to understand what is / is not tested.
-- Default clock frequency of examples is 8Mhz with an embassy tick frequency of 10Khz. This is changed
-  because default embassy tick of embassy_time is 1Mhz which is too fast.
-  Chose an embassy tick frequency fiting to your project.
 
 ### TODOs
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ For a full list of chip capabilities and peripherals, check the [ch32-data](http
 
 ### Notes
 - For USB OTGFS and HS, look at the `mod.rs` respsectively to understand what is / is not tested.
+- Default clock frequency of examples is 8Mhz with an embassy tick frequency of 10Khz. This is changed
+  because default embassy tick of embassy_time is 1Mhz which is too fast.
+  Chose an embassy tick frequency fiting to your project.
 
 ### TODOs
 

--- a/examples/ch32l103/Cargo.toml
+++ b/examples/ch32l103/Cargo.toml
@@ -11,12 +11,11 @@ ch32-hal = { path = "../../", features = [
     "rt",
     "time-driver-tim2",
 ], default-features = false }
-embassy-executor = { version = "0.6.0", features = [
-    "integrated-timers",
+embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.3.2" }
+embassy-time = { version = "0.4.0" }
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "*"

--- a/examples/ch32l103/Cargo.toml
+++ b/examples/ch32l103/Cargo.toml
@@ -15,7 +15,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
+embassy-time = "0.4.0"
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "*"

--- a/examples/ch32l103/Cargo.toml
+++ b/examples/ch32l103/Cargo.toml
@@ -15,7 +15,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "*"

--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -16,7 +16,7 @@ embassy-executor = { version = "0.7.0", features = [
     "executor-thread",
     "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
 ] }
-embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
+embassy-time = version = "0.4.0"
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "*"

--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -11,13 +11,12 @@ ch32-hal = { path = "../../", features = [
     "time-driver-tim2",
     "rt",
 ] }
-embassy-executor = { version = "0.6.0", features = [
-    "integrated-timers",
+embassy-executor = { version = "0.7.0", features = [
     "arch-spin",
     "executor-thread",
     "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
 ] }
-embassy-time = { version = "0.3.0" }
+embassy-time = { version = "0.4.0" }
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "*"

--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -16,7 +16,7 @@ embassy-executor = { version = "0.7.0", features = [
     "executor-thread",
     "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
 ] }
-embassy-time = version = "0.4.0"
+embassy-time = "0.4.0"
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "*"

--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -16,7 +16,7 @@ embassy-executor = { version = "0.7.0", features = [
     "executor-thread",
     "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "*"

--- a/examples/ch32v103/Cargo.toml
+++ b/examples/ch32v103/Cargo.toml
@@ -10,12 +10,11 @@ ch32-hal = { path = "../../", features = [
     "rt",
     "time-driver-tim2",
 ] }
-embassy-executor = { version = "0.6.0", features = [
-    "integrated-timers",
+embassy-executor = { version = "0.7.0", features = [
     "arch-spin",
     "executor-thread",
 ] }
-embassy-time = { version = "0.3.2" }
+embassy-time = { version = "0.4.0" }
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke-rt = "*"

--- a/examples/ch32v103/Cargo.toml
+++ b/examples/ch32v103/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-spin",
     "executor-thread",
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke-rt = "*"

--- a/examples/ch32v103/Cargo.toml
+++ b/examples/ch32v103/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-spin",
     "executor-thread",
 ] }
-embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
+embassy-time = "0.4.0"
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke-rt = "*"

--- a/examples/ch32v203/Cargo.toml
+++ b/examples/ch32v203/Cargo.toml
@@ -17,7 +17,7 @@ embassy-executor = { version = "0.7.0", features = [
     "executor-thread",
 ] }
 
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 embassy-usb = { version = "0.3.0" }
 embassy-futures = { version = "0.1.0" }
 

--- a/examples/ch32v203/Cargo.toml
+++ b/examples/ch32v203/Cargo.toml
@@ -17,7 +17,7 @@ embassy-executor = { version = "0.7.0", features = [
     "executor-thread",
 ] }
 
-embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
+embassy-time = "0.4.0"
 embassy-usb = { version = "0.3.0" }
 embassy-futures = { version = "0.1.0" }
 

--- a/examples/ch32v203/Cargo.toml
+++ b/examples/ch32v203/Cargo.toml
@@ -12,13 +12,12 @@ ch32-hal = { path = "../../", features = [
     "time-driver-tim2",
 ], default-features = false }
 
-embassy-executor = { version = "0.6.0", features = [
-    "integrated-timers",
+embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
 
-embassy-time = { version = "0.3.2" }
+embassy-time = { version = "0.4.0" }
 embassy-usb = { version = "0.3.0" }
 embassy-futures = { version = "0.1.0" }
 

--- a/examples/ch32v208/Cargo.toml
+++ b/examples/ch32v208/Cargo.toml
@@ -10,12 +10,11 @@ ch32-hal = { path = "../../", features = [
     "embassy",
     "rt",
 ], default-features = false }
-embassy-executor = { version = "0.6.0", features = [
-    "integrated-timers",
+embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.3.2" }
+embassy-time = { version = "0.4.0" }
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke-rt = "*"

--- a/examples/ch32v208/Cargo.toml
+++ b/examples/ch32v208/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke-rt = "*"

--- a/examples/ch32v208/Cargo.toml
+++ b/examples/ch32v208/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
+embassy-time = "0.4.0"
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke-rt = "*"

--- a/examples/ch32v305/Cargo.toml
+++ b/examples/ch32v305/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 
 qingke-rt = "*"
 qingke = "*"

--- a/examples/ch32v305/Cargo.toml
+++ b/examples/ch32v305/Cargo.toml
@@ -10,12 +10,11 @@ ch32-hal = { path = "../../", features = [
     "embassy",
     "rt",
 ] }
-embassy-executor = { version = "0.6.0", features = [
-    "integrated-timers",
+embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.3.2" }
+embassy-time = { version = "0.4.0" }
 
 qingke-rt = "*"
 qingke = "*"

--- a/examples/ch32v305/Cargo.toml
+++ b/examples/ch32v305/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
+embassy-time = "0.4.0"
 
 qingke-rt = "*"
 qingke = "*"

--- a/examples/ch32v307/Cargo.toml
+++ b/examples/ch32v307/Cargo.toml
@@ -19,7 +19,7 @@ embassy-executor = { version = "0.7.0", features = [
 
 critical-section = "1.2.0"
 
-embassy-time = "0.4.0"
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 embassy-usb = "0.3.0"
 nb = "1.1.0"
 

--- a/examples/ch32v307/Cargo.toml
+++ b/examples/ch32v307/Cargo.toml
@@ -19,7 +19,7 @@ embassy-executor = { version = "0.7.0", features = [
 
 critical-section = "1.2.0"
 
-embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
+embassy-time = "0.4.0"
 embassy-usb = "0.3.0"
 nb = "1.1.0"
 

--- a/examples/ch32v307/Cargo.toml
+++ b/examples/ch32v307/Cargo.toml
@@ -12,15 +12,14 @@ ch32-hal = { path = "../../", features = [
     "highcode",
     "time-driver-tim1",
 ] }
-embassy-executor = { version = "0.6.0", features = [
-    "integrated-timers",
+embassy-executor = { version = "0.7.0", features = [
     "arch-spin",
     "executor-thread",
 ] }
 
 critical-section = "1.2.0"
 
-embassy-time = "0.3.2"
+embassy-time = "0.4.0"
 embassy-usb = "0.3.0"
 nb = "1.1.0"
 

--- a/examples/ch32x035/Cargo.toml
+++ b/examples/ch32x035/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 
 qingke-rt = "*"
 qingke = "*"

--- a/examples/ch32x035/Cargo.toml
+++ b/examples/ch32x035/Cargo.toml
@@ -10,12 +10,11 @@ ch32-hal = { path = "../../", features = [
     "embassy",
     "rt",
 ] }
-embassy-executor = { version = "0.6.0", features = [
-    "integrated-timers",
+embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.3.2" }
+embassy-time = { version = "0.4.0" }
 
 qingke-rt = "*"
 qingke = "*"

--- a/examples/ch32x035/Cargo.toml
+++ b/examples/ch32x035/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
+embassy-time = "0.4.0"
 
 qingke-rt = "*"
 qingke = "*"

--- a/examples/ch641/Cargo.toml
+++ b/examples/ch641/Cargo.toml
@@ -16,7 +16,7 @@ embassy-executor = { version = "0.7.0", features = [
     "executor-thread",
     "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
 ] }
-embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
+embassy-time = "0.4.0"
 embedded-hal = "1.0.0"
 
 qingke-rt = "*"

--- a/examples/ch641/Cargo.toml
+++ b/examples/ch641/Cargo.toml
@@ -11,13 +11,12 @@ ch32-hal = { path = "../../", features = [
     "time-driver-tim2",
     "rt",
 ] }
-embassy-executor = { version = "0.6.0", features = [
-    "integrated-timers",
+embassy-executor = { version = "0.7.0", features = [
     "arch-riscv32",
     "executor-thread",
     "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
 ] }
-embassy-time = { version = "0.3.2" }
+embassy-time = { version = "0.4.0" }
 embedded-hal = "1.0.0"
 
 qingke-rt = "*"

--- a/examples/ch641/Cargo.toml
+++ b/examples/ch641/Cargo.toml
@@ -16,7 +16,7 @@ embassy-executor = { version = "0.7.0", features = [
     "executor-thread",
     "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
 ] }
-embassy-time = { version = "0.4.0" }
+embassy-time = {version = "0.4.0", features = ["tick-hz-10_000",]}
 embedded-hal = "1.0.0"
 
 qingke-rt = "*"

--- a/src/embassy/mod.rs
+++ b/src/embassy/mod.rs
@@ -26,9 +26,9 @@ pub mod time_driver_impl;
 pub unsafe fn init() {
     crate::pac::PFIC.sctlr().modify(|w| w.set_sevonpend(true));
 
-    #[cfg(all(qingke_v4, not(time_driver_timer)))]
-    time_driver_impl::init();
-
-    #[cfg(time_driver_timer)]
+    #[cfg(any(qingke_v4, time_driver_timer))]
     critical_section::with(|cs| time_driver_impl::init(cs));
+
+    #[cfg(not(any(qingke_v4, time_driver_timer)))]
+    compile_error!("No timer source for embassy given");
 }

--- a/src/embassy/mod.rs
+++ b/src/embassy/mod.rs
@@ -28,7 +28,4 @@ pub unsafe fn init() {
 
     #[cfg(any(qingke_v4, time_driver_timer))]
     critical_section::with(|cs| time_driver_impl::init(cs));
-
-    #[cfg(not(any(qingke_v4, time_driver_timer)))]
-    compile_error!("No timer source for embassy given");
 }

--- a/src/embassy/time_driver_systick.rs
+++ b/src/embassy/time_driver_systick.rs
@@ -1,6 +1,6 @@
 //! SysTick-based time driver.
 
-use core::cell::{Cell, RefCell};
+use core::cell::RefCell;
 use core::sync::atomic::{AtomicU32, Ordering};
 use critical_section::CriticalSection;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
@@ -18,30 +18,13 @@ fn SysTick() {
     DRIVER.on_interrupt();
 }
 
-struct AlarmState {
-    timestamp: Cell<u64>,
-}
-
-unsafe impl Send for AlarmState {}
-
-impl AlarmState {
-    const fn new() -> Self {
-        Self {
-            timestamp: Cell::new(u64::MAX),
-        }
-    }
-}
-
 pub struct SystickDriver {
-    period: AtomicU32,
-    /// Timestamp at which to fire alarm. u64::MAX if no alarm is scheduled.
-    alarm: Mutex<CriticalSectionRawMutex, AlarmState>,
+    cnt_per_tick: AtomicU32,
     queue: Mutex<CriticalSectionRawMutex, RefCell<Queue>>,
 }
 
 embassy_time_driver::time_driver_impl!(static DRIVER: SystickDriver = SystickDriver {
-    period: AtomicU32::new(1), // avoid div by zero
-    alarm: Mutex::const_new(CriticalSectionRawMutex::new(), AlarmState::new()),
+    cnt_per_tick: AtomicU32::new(1), // avoid div by zero
     queue: Mutex::new(RefCell::new(Queue::new()))
 });
 
@@ -53,44 +36,37 @@ impl SystickDriver {
         let cnt_per_second = hclk / 8; // HCLK/8
         let cnt_per_tick = cnt_per_second / embassy_time_driver::TICK_HZ;
 
-        self.period.store(cnt_per_tick as u32, Ordering::Relaxed);
+        self.cnt_per_tick.store(cnt_per_tick as u32, Ordering::Relaxed);
 
-        // UNDOCUMENTED:  Avoid initial interrupt
-        r.cmp().write(|w| *w = u64::MAX - 1);
-        r.cmp().write_value(0);
+        r.ctlr().write(|w| {
+            // Everything else is set to default (0)
+            w.set_init(true); // Initialize counter
+            w.set_ste(true); // Enable counter
+        });
 
-        //Count value compare flag
+        // Write 0 to both halves of the compare register
+        r.cmph().write_value(0);
+        r.cmpl().write_value(0);
+
+        // Count value compare flag
         r.sr().write(|w| w.set_cntif(false)); // clear
 
-        // Configration: Upcount, No reload, HCLK as clock source
+        // Configration: Upcount, No reload, HCLK/8 as clock source
         r.ctlr().modify(|w| {
-            //  w.set_init(true);
-            w.set_mode(vals::Mode::UPCOUNT);//Counter mode
-            w.set_stre(false);//Auto reload count enable bit
-            w.set_stclk(vals::Stclk::HCLK_DIV8);//Counter system clock sourse selection bit
-            w.set_ste(true);//Counter enable control bit
+            w.set_mode(vals::Mode::UPCOUNT); // Counter mode
+            w.set_stre(false); // Auto reload count enable bit
+            w.set_stclk(vals::Stclk::HCLK_DIV8); // Counter system clock sourse selection bit
         });
     }
 
-    #[inline(always)]
     fn on_interrupt(&self) {
         let r = &crate::pac::SYSTICK;
-        //Count value compare flag
+        // Count value compare flag
         r.sr().write(|w| w.set_cntif(false)); // clear IF
 
-        let period = self.period.load(Ordering::Relaxed) as u64;
-
-        let next_timestamp = critical_section::with(|cs| {
-            let next = self.alarm.borrow(cs).timestamp.get();
-            if next > self.now() + 1 {
-                return next;
-            }
+        critical_section::with(|cs| {
             self.trigger_alarm(cs);
-            return u64::MAX;
         });
-
-        let new_cmp = u64::min(next_timestamp.saturating_mul(period), self.raw_cnt().wrapping_add(period));
-        r.cmp().write_value(new_cmp.saturating_add(1));
     }
 
     #[inline]
@@ -100,32 +76,35 @@ impl SystickDriver {
     }
 
     fn trigger_alarm(&self, cs: CriticalSection) {
-        let mut next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+        let mut next = self.queue.borrow(cs).borrow_mut().next_expiration(self.raw_cnt());
         while !self.set_alarm(cs, next) {
-            next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+            next = self.queue.borrow(cs).borrow_mut().next_expiration(self.raw_cnt());
         }
     }
 
-    fn set_alarm(&self, cs: CriticalSection, timestamp: u64) -> bool {
+    fn set_alarm(&self, _cs: CriticalSection, next_alarm_cnt: u64) -> bool {
         let r = &crate::pac::SYSTICK;
 
-        self.alarm.borrow(cs).timestamp.set(timestamp);
-
-        let period = self.period.load(Ordering::Relaxed) as u64;
-
-        // See-also: https://github.com/ch32-rs/ch32-hal/issues/4
-        let t = self.raw_cnt();
-        let timestamp = timestamp.saturating_mul(period);
-        if timestamp <= t {
+        // TODO move this to schedule_wake
+        if next_alarm_cnt <= self.raw_cnt() {
             // If alarm timestamp has passed the alarm will not fire.
             // Disarm the alarm and return `false` to indicate that.
-
-            self.alarm.borrow(cs).timestamp.set(u64::MAX);
-
             return false;
         }
-        //Counter interrupt enable control bit
+
+        // Counter interrupt enable control bit
+        r.cmph().write_value((next_alarm_cnt >> 32) as u32);
+        r.cmpl().write_value((next_alarm_cnt) as u32);
         r.ctlr().modify(|w| w.set_stie(true));
+        r.sr().write(|w| w.set_cntif(false));
+
+        if next_alarm_cnt <= self.raw_cnt() {
+            // If alarm timestamp has passed the alarm will not fire.
+            // Disarm the alarm and return `false` to indicate that.
+            r.ctlr().modify(|w| w.set_stie(false));
+            r.sr().write(|w| w.set_cntif(false));
+            return false;
+        }
 
         true
     }
@@ -133,18 +112,19 @@ impl SystickDriver {
 
 impl Driver for SystickDriver {
     fn now(&self) -> u64 {
-        let period = self.period.load(Ordering::Relaxed) as u64;
-        self.raw_cnt() / period
+        let cnt_per_tick = self.cnt_per_tick.load(Ordering::Relaxed) as u64;
+        self.raw_cnt() / cnt_per_tick
     }
 
-    fn schedule_wake(&self, at: u64, waker: &core::task::Waker) {
+    fn schedule_wake(&self, ticks: u64, waker: &core::task::Waker) {
+        let cnt_per_tick = self.cnt_per_tick.load(Ordering::Relaxed) as u64;
         critical_section::with(|cs| {
             let mut queue = self.queue.borrow(cs).borrow_mut();
 
-            if queue.schedule_wake(at, waker) {
-                let mut next = queue.next_expiration(self.now());
+            if queue.schedule_wake(ticks * cnt_per_tick, waker) {
+                let mut next = queue.next_expiration(self.raw_cnt());
                 while !self.set_alarm(cs, next) {
-                    next = queue.next_expiration(self.now());
+                    next = queue.next_expiration(self.raw_cnt());
                 }
             }
         })

--- a/src/embassy/time_driver_tim.rs
+++ b/src/embassy/time_driver_tim.rs
@@ -7,24 +7,22 @@
 
 #![allow(non_snake_case)]
 
-use core::cell::Cell;
-use core::sync::atomic::{compiler_fence, AtomicU32, AtomicU8, Ordering};
-use core::{mem, ptr};
+use core::cell::{Cell, RefCell};
+use core::sync::atomic::{compiler_fence, AtomicU32, Ordering};
 
 use critical_section::CriticalSection;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::blocking_mutex::Mutex;
-use embassy_time_driver::{AlarmHandle, Driver, TICK_HZ};
+use embassy_time_driver::{Driver, TICK_HZ};
+use embassy_time_queue_utils::Queue;
 use qingke_rt::interrupt;
 
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac::timer::{regs, vals, Gptm};
 use crate::peripheral::SealedRccPeripheral;
 use crate::peripherals;
-// for ::regs()
-use crate::timer::{CoreInstance, GeneralInstance16bit};
 
-const ALARM_COUNT: usize = 1;
+use crate::timer::{CoreInstance, GeneralInstance16bit};
 
 #[cfg(time_driver_tim1)]
 type T = peripherals::TIM1;
@@ -80,7 +78,7 @@ foreach_interrupt! {
         #[cfg(time_driver_tim5)]
         #[cfg(feature = "rt")]
         #[interrupt]
-        fn$irq() {
+        fn $irq() {
             DRIVER.on_interrupt()
         }
     };
@@ -88,7 +86,7 @@ foreach_interrupt! {
         #[cfg(time_driver_tim8)]
         #[cfg(feature = "rt")]
         #[interrupt]
-        fn$irq() {
+        fn $irq() {
             DRIVER.on_interrupt()
         }
     };
@@ -96,7 +94,7 @@ foreach_interrupt! {
         #[cfg(time_driver_tim9)]
         #[cfg(feature = "rt")]
         #[interrupt]
-        fn$irq() {
+        fn $irq() {
             DRIVER.on_interrupt()
         }
     };
@@ -104,7 +102,7 @@ foreach_interrupt! {
         #[cfg(time_driver_tim10)]
         #[cfg(feature = "rt")]
         #[interrupt]
-        fn$irq() {
+        fn $irq() {
             DRIVER.on_interrupt()
         }
     };
@@ -138,11 +136,6 @@ fn calc_now(period: u32, counter: u16) -> u64 {
 
 struct AlarmState {
     timestamp: Cell<u64>,
-
-    // This is really a Option<(fn(*mut ()), *mut ())>
-    // but fn pointers aren't allowed in const yet
-    callback: Cell<*const ()>,
-    ctx: Cell<*mut ()>,
 }
 
 unsafe impl Send for AlarmState {}
@@ -151,8 +144,6 @@ impl AlarmState {
     const fn new() -> Self {
         Self {
             timestamp: Cell::new(u64::MAX),
-            callback: Cell::new(ptr::null()),
-            ctx: Cell::new(ptr::null_mut()),
         }
     }
 }
@@ -160,18 +151,15 @@ impl AlarmState {
 pub(crate) struct RtcDriver {
     /// Number of 2^15 periods elapsed since boot.
     period: AtomicU32,
-    alarm_count: AtomicU8,
     /// Timestamp at which to fire alarm. u64::MAX if no alarm is scheduled.
-    alarms: Mutex<CriticalSectionRawMutex, [AlarmState; ALARM_COUNT]>,
+    alarm: Mutex<CriticalSectionRawMutex, AlarmState>,
+    queue: Mutex<CriticalSectionRawMutex, RefCell<Queue>>,
 }
-
-#[allow(clippy::declare_interior_mutable_const)]
-const ALARM_STATE_NEW: AlarmState = AlarmState::new();
 
 embassy_time_driver::time_driver_impl!(static DRIVER: RtcDriver = RtcDriver {
     period: AtomicU32::new(0),
-    alarm_count: AtomicU8::new(0),
-    alarms: Mutex::const_new(CriticalSectionRawMutex::new(), [ALARM_STATE_NEW; ALARM_COUNT]),
+    alarm: Mutex::const_new(CriticalSectionRawMutex::new(), AlarmState::new()),
+    queue: Mutex::new(RefCell::new(Queue::new()))
 });
 
 impl RtcDriver {
@@ -237,10 +225,8 @@ impl RtcDriver {
                 self.next_period();
             }
 
-            for n in 0..ALARM_COUNT {
-                if sr.ccif(n + 1) && dier.ccie(n + 1) {
-                    self.trigger_alarm(n, cs);
-                }
+            if sr.ccif(1) && dier.ccie(1) {
+                self.trigger_alarm(cs);
             }
         })
     }
@@ -255,36 +241,65 @@ impl RtcDriver {
 
         critical_section::with(move |cs| {
             r.dmaintenr().modify(move |w| {
-                for n in 0..ALARM_COUNT {
-                    let alarm = &self.alarms.borrow(cs)[n];
-                    let at = alarm.timestamp.get();
+                let alarm = self.alarm.borrow(cs);
+                let at = alarm.timestamp.get();
 
-                    if at < t + 0xc000 {
-                        // just enable it. `set_alarm` has already set the correct CCR val.
-                        w.set_ccie(n + 1, true);
-                    }
+                if at < t + 0xc000 {
+                    // just enable it. `set_alarm` has already set the correct CCR val.
+                      w.set_ccie(1, true);
                 }
             })
         })
     }
 
-    fn get_alarm<'a>(&'a self, cs: CriticalSection<'a>, alarm: AlarmHandle) -> &'a AlarmState {
-        // safety: we're allowed to assume the AlarmState is created by us, and
-        // we never create one that's out of bounds.
-        unsafe { self.alarms.borrow(cs).get_unchecked(alarm.id() as usize) }
+    fn trigger_alarm(&self, cs: CriticalSection) {
+        let mut next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+        while !self.set_alarm(cs, next) {
+            next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+        }
     }
 
-    fn trigger_alarm(&self, n: usize, cs: CriticalSection) {
-        let alarm = &self.alarms.borrow(cs)[n];
-        alarm.timestamp.set(u64::MAX);
+    fn set_alarm(&self, cs: CriticalSection, timestamp: u64) -> bool {
+        let r = regs_gp16();
 
-        // Call after clearing alarm, so the callback can set another alarm.
+        let n = 0;
+        self.alarm.borrow(cs).timestamp.set(timestamp);
 
-        // safety:
-        // - we can ignore the possibility of `f` being unset (null) because of the safety contract of `allocate_alarm`.
-        // - other than that we only store valid function pointers into alarm.callback
-        let f: fn(*mut ()) = unsafe { mem::transmute(alarm.callback.get()) };
-        f(alarm.ctx.get());
+        let t = self.now();
+        if timestamp <= t {
+            // If alarm timestamp has passed the alarm will not fire.
+            // Disarm the alarm and return `false` to indicate that.
+            r.dmaintenr().modify(|w| w.set_ccie(n + 1, false));
+
+            self.alarm.borrow(cs).timestamp.set(u64::MAX);
+
+            return false;
+        }
+
+            // Write the CCR value regardless of whether we're going to enable it now or not.
+            // This way, when we enable it later, the right value is already set.
+            r.chcvr(n + 1).write_value(timestamp as u16);
+
+            // Enable it if it'll happen soon. Otherwise, `next_period` will enable it.
+            let diff = timestamp - t;
+            r.dmaintenr().modify(|w| w.set_ccie(n + 1, diff < 0xc000));
+
+        // Reevaluate if the alarm timestamp is still in the future
+        let t = self.now();
+        if timestamp <= t {
+            // If alarm timestamp has passed since we set it, we have a race condition and
+            // the alarm may or may not have fired.
+            // Disarm the alarm and return `false` to indicate that.
+            // It is the caller's responsibility to handle this ambiguity.
+            r.dmaintenr().modify(|w| w.set_ccie(n + 1, false));
+
+            self.alarm.borrow(cs).timestamp.set(u64::MAX);
+
+            return false;
+        }
+
+        // We're confident the alarm will ring in the future.
+        true
     }
 }
 
@@ -298,70 +313,16 @@ impl Driver for RtcDriver {
         calc_now(period, counter)
     }
 
-    unsafe fn allocate_alarm(&self) -> Option<AlarmHandle> {
-        critical_section::with(|_| {
-            let id = self.alarm_count.load(Ordering::Relaxed);
-            if id < ALARM_COUNT as u8 {
-                self.alarm_count.store(id + 1, Ordering::Relaxed);
-                Some(AlarmHandle::new(id))
-            } else {
-                None
-            }
-        })
-    }
-
-    fn set_alarm_callback(&self, alarm: AlarmHandle, callback: fn(*mut ()), ctx: *mut ()) {
+    fn schedule_wake(&self, at: u64, waker: &core::task::Waker) {
         critical_section::with(|cs| {
-            let alarm = self.get_alarm(cs, alarm);
+            let mut queue = self.queue.borrow(cs).borrow_mut();
 
-            alarm.callback.set(callback as *const ());
-            alarm.ctx.set(ctx);
-        })
-    }
-
-    fn set_alarm(&self, alarm: AlarmHandle, timestamp: u64) -> bool {
-        critical_section::with(|cs| {
-            let r = regs_gp16();
-
-            let n = alarm.id() as usize;
-            let alarm = self.get_alarm(cs, alarm);
-            alarm.timestamp.set(timestamp);
-
-            let t = self.now();
-            if timestamp <= t {
-                // If alarm timestamp has passed the alarm will not fire.
-                // Disarm the alarm and return `false` to indicate that.
-                r.dmaintenr().modify(|w| w.set_ccie(n + 1, false));
-
-                alarm.timestamp.set(u64::MAX);
-
-                return false;
+            if queue.schedule_wake(at, waker) {
+                let mut next = queue.next_expiration(self.now());
+                while !self.set_alarm(cs, next) {
+                    next = queue.next_expiration(self.now());
+                }
             }
-
-            // Write the CCR value regardless of whether we're going to enable it now or not.
-            // This way, when we enable it later, the right value is already set.
-            r.chcvr(n + 1).write_value(timestamp as u16);
-
-            // Enable it if it'll happen soon. Otherwise, `next_period` will enable it.
-            let diff = timestamp - t;
-            r.dmaintenr().modify(|w| w.set_ccie(n + 1, diff < 0xc000));
-
-            // Reevaluate if the alarm timestamp is still in the future
-            let t = self.now();
-            if timestamp <= t {
-                // If alarm timestamp has passed since we set it, we have a race condition and
-                // the alarm may or may not have fired.
-                // Disarm the alarm and return `false` to indicate that.
-                // It is the caller's responsibility to handle this ambiguity.
-                r.dmaintenr().modify(|w| w.set_ccie(n + 1, false));
-
-                alarm.timestamp.set(u64::MAX);
-
-                return false;
-            }
-
-            // We're confident the alarm will ring in the future.
-            true
         })
     }
 }

--- a/src/embassy/time_driver_tim.rs
+++ b/src/embassy/time_driver_tim.rs
@@ -246,7 +246,7 @@ impl RtcDriver {
 
                 if at < t + 0xc000 {
                     // just enable it. `set_alarm` has already set the correct CCR val.
-                      w.set_ccie(1, true);
+                    w.set_ccie(1, true);
                 }
             })
         })
@@ -276,13 +276,13 @@ impl RtcDriver {
             return false;
         }
 
-            // Write the CCR value regardless of whether we're going to enable it now or not.
-            // This way, when we enable it later, the right value is already set.
-            r.chcvr(n + 1).write_value(timestamp as u16);
+        // Write the CCR value regardless of whether we're going to enable it now or not.
+        // This way, when we enable it later, the right value is already set.
+        r.chcvr(n + 1).write_value(timestamp as u16);
 
-            // Enable it if it'll happen soon. Otherwise, `next_period` will enable it.
-            let diff = timestamp - t;
-            r.dmaintenr().modify(|w| w.set_ccie(n + 1, diff < 0xc000));
+        // Enable it if it'll happen soon. Otherwise, `next_period` will enable it.
+        let diff = timestamp - t;
+        r.dmaintenr().modify(|w| w.set_ccie(n + 1, diff < 0xc000));
 
         // Reevaluate if the alarm timestamp is still in the future
         let t = self.now();

--- a/src/embassy/time_driver_tim.rs
+++ b/src/embassy/time_driver_tim.rs
@@ -149,9 +149,9 @@ impl AlarmState {
 }
 
 pub(crate) struct RtcDriver {
-    /// Number of 2^15 periods elapsed since boot.
+    // Number of 2^15 periods elapsed since boot.
     period: AtomicU32,
-    /// Timestamp at which to fire alarm. u64::MAX if no alarm is scheduled.
+    // Timestamp at which to fire alarm. u64::MAX if no alarm is scheduled.
     alarm: Mutex<CriticalSectionRawMutex, AlarmState>,
     queue: Mutex<CriticalSectionRawMutex, RefCell<Queue>>,
 }
@@ -170,7 +170,7 @@ impl RtcDriver {
 
         let timer_freq = T::frequency();
 
-        r.ctlr1().modify(|w| w.set_cen(false));//Counter enable
+        r.ctlr1().modify(|w| w.set_cen(false)); // Counter enable
         r.cnt().write_value(0);
 
         let psc = timer_freq.0 / TICK_HZ as u32 - 1;
@@ -179,21 +179,21 @@ impl RtcDriver {
             Ok(n) => n,
         };
 
-        r.psc().write_value(psc);//prescaler
-        r.atrlr().write_value(u16::MAX);//auto-reload register
+        r.psc().write_value(psc); // prescaler
+        r.atrlr().write_value(u16::MAX); // auto-reload register
 
         // Set URS, generate update and clear URS
-        r.ctlr1().modify(|w| w.set_urs(vals::Urs::COUNTERONLY));//Update request source
-        r.swevgr().write(|w| w.set_ug(true));//Update generation
-        r.ctlr1().modify(|w| w.set_urs(vals::Urs::ANYEVENT));//Update request source
+        r.ctlr1().modify(|w| w.set_urs(vals::Urs::COUNTERONLY)); // Update request source
+        r.swevgr().write(|w| w.set_ug(true)); // Update generation
+        r.ctlr1().modify(|w| w.set_urs(vals::Urs::ANYEVENT)); // Update request source
 
         // Mid-way point. CC1
-        r.chcvr(0).write_value(0x8000);//capture/compare register 1
+        r.chcvr(0).write_value(0x8000); // capture/compare register 1
 
         // Enable overflow and half-overflow interrupts
         r.dmaintenr().write(|w| {
-            w.set_uie(true);//Update interrupt enable
-            w.set_ccie(0, true);//Capture/Compare 1 interrupt enable
+            w.set_uie(true); // Update interrupt enable
+            w.set_ccie(0, true); // Capture/Compare 1 interrupt enable
         });
 
         <T as GeneralInstance16bit>::CaptureCompareInterrupt::unpend();
@@ -207,8 +207,8 @@ impl RtcDriver {
 
         // XXX: reduce the size of this critical section ?
         critical_section::with(|cs| {
-            let sr = r.intfr().read();//status register
-            let dier = r.dmaintenr().read();//DMA/Interrupt enable register
+            let sr = r.intfr().read(); // status register
+            let dier = r.dmaintenr().read(); // DMA/Interrupt enable register
 
             // Clear all interrupt flags. Bits in SR are "write 0 to clear", so write the bitwise NOT.
             // Other approaches such as writing all zeros, or RMWing won't work, they can
@@ -216,16 +216,16 @@ impl RtcDriver {
             r.intfr().write_value(regs::Intfr(!sr.0));
 
             // Overflow
-            if sr.uif() {//Update interrupt flag
+            if sr.uif() { // Update interrupt flag
                 self.next_period();
             }
 
             // Half overflow
-            if sr.ccif(0) {//Capture/compare 1 interrupt flag
+            if sr.ccif(0) { // Capture/compare 1 interrupt flag
                 self.next_period();
             }
 
-            if sr.ccif(1) && dier.ccie(1) {//Capture/compare 1 interrupt flag & Capture/Compare 1 interrupt enable
+            if sr.ccif(1) && dier.ccie(1) { // Capture/compare 1 interrupt flag & Capture/Compare 1 interrupt enable
                 self.trigger_alarm(cs);
             }
         })
@@ -246,7 +246,7 @@ impl RtcDriver {
 
                 if at < t + 0xc000 {
                     // just enable it. `set_alarm` has already set the correct CCR val.
-                    w.set_ccie(1, true);//Capture/Compare 1 interrupt enable
+                    w.set_ccie(1, true); // Capture/Compare 1 interrupt enable
                 }
             })
         })
@@ -268,7 +268,7 @@ impl RtcDriver {
         if timestamp <= t {
             // If alarm timestamp has passed the alarm will not fire.
             // Disarm the alarm and return `false` to indicate that.
-            r.dmaintenr().modify(|w| w.set_ccie(1, false));//Capture/Compare 1 interrupt enable
+            r.dmaintenr().modify(|w| w.set_ccie(1, false)); // Capture/Compare 1 interrupt enable
 
             self.alarm.borrow(cs).timestamp.set(u64::MAX);
 
@@ -277,11 +277,11 @@ impl RtcDriver {
 
         // Write the CCR value regardless of whether we're going to enable it now or not.
         // This way, when we enable it later, the right value is already set.
-        r.chcvr(1).write_value(timestamp as u16);//capture/compare register 1
+        r.chcvr(1).write_value(timestamp as u16); // capture/compare register 1
 
         // Enable it if it'll happen soon. Otherwise, `next_period` will enable it.
         let diff = timestamp - t;
-        r.dmaintenr().modify(|w| w.set_ccie(1, diff < 0xc000));//Capture/Compare 1 interrupt enable
+        r.dmaintenr().modify(|w| w.set_ccie(1, diff < 0xc000)); // Capture/Compare 1 interrupt enable
 
         // Reevaluate if the alarm timestamp is still in the future
         let t = self.now();
@@ -290,7 +290,7 @@ impl RtcDriver {
             // the alarm may or may not have fired.
             // Disarm the alarm and return `false` to indicate that.
             // It is the caller's responsibility to handle this ambiguity.
-            r.dmaintenr().modify(|w| w.set_ccie(1, false));//Capture/Compare 1 interrupt enable
+            r.dmaintenr().modify(|w| w.set_ccie(1, false)); // Capture/Compare 1 interrupt enable
 
             self.alarm.borrow(cs).timestamp.set(u64::MAX);
 


### PR DESCRIPTION
Hello,

I have adapted time_driver_tim.rs in the same manner as time_driver.rs is for stm32 in embassy repo. embassy_time with version 0.4.0 should now be possible as requested by #82  