### PR TITLE
fix(examples/ch32v003): Remove some strings so the binary size fits into flash/ram

### DIFF
--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -35,4 +35,7 @@ micromath = { version = "2.1.0", features = ["num-traits"] }
 [profile.release]
 strip = false   # symbols are not flashed to the microcontroller, so don't strip them.
 lto = true
-opt-level = "s" # Optimize for size.
+opt-level = "z" # Optimize for size.
+
+[profile.dev]
+overflow-checks = false

--- a/examples/ch32v003/src/bin/spi-lcd-st7735-cube.rs
+++ b/examples/ch32v003/src/bin/spi-lcd-st7735-cube.rs
@@ -437,7 +437,8 @@ fn main() -> ! {
 
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
-    let _ = println!("\n\n\n{}", info);
+    // CH32V003 is so resource constrained, adding strings is a bad idea.
+    // let _ = println!("\n\n\n{}", info);
 
     loop {}
 }


### PR DESCRIPTION
Emergency fix for the TOT being broken