### PR TITLE
Make `nb_read` public outside of crate

### DIFF
--- a/src/usart/mod.rs
+++ b/src/usart/mod.rs
@@ -402,7 +402,7 @@ impl<'d, T: Instance, M: Mode> UartRx<'d, T, M> {
 
     /// Read a single u8 if there is one available, otherwise return WouldBlock
     #[allow(unused)]
-    pub(crate) fn nb_read(&mut self) -> Result<u8, nb::Error<Error>> {
+    pub fn nb_read(&mut self) -> Result<u8, nb::Error<Error>> {
         let r = T::regs();
         if self.check_rx_flags()? {
             Ok(r.datar().read().dr() as u8)


### PR DESCRIPTION
Unless I have missed something, there is no way to perform a non-blocking read, or even to check to see if data is available on the UART. This PR simply exposes an internal function to read a single byte if there is one available.