### PR TITLE
embassy-usb-driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ embassy-futures = { version = "0.1.1" }
 embassy-time-queue-utils = { version = "0.1", optional = true }
 embassy-time-driver = { version = "0.2.0", optional = true }
 embassy-time = { version = "0.4.0", optional = true }
-embassy-usb-driver = "0.1.0"
+embassy-usb-driver = "0.2.0"
 
 nb = "1.1.0"
 embedded-hal-nb = "1.0.0"

--- a/src/embassy/time_driver_tim.rs
+++ b/src/embassy/time_driver_tim.rs
@@ -199,7 +199,7 @@ impl RtcDriver {
         <T as GeneralInstance16bit>::CaptureCompareInterrupt::unpend();
         unsafe { <T as GeneralInstance16bit>::CaptureCompareInterrupt::enable() };
 
-        r.ctlr1().modify(|w| w.set_cen(true));//Counter enable
+        r.ctlr1().modify(|w| w.set_cen(true)); //Counter enable
     }
 
     fn on_interrupt(&self) {
@@ -216,16 +216,19 @@ impl RtcDriver {
             r.intfr().write_value(regs::Intfr(!sr.0));
 
             // Overflow
-            if sr.uif() { // Update interrupt flag
+            if sr.uif() {
+                // Update interrupt flag
                 self.next_period();
             }
 
             // Half overflow
-            if sr.ccif(0) { // Capture/compare 1 interrupt flag
+            if sr.ccif(0) {
+                // Capture/compare 1 interrupt flag
                 self.next_period();
             }
 
-            if sr.ccif(1) && dier.ccie(1) { // Capture/compare 1 interrupt flag & Capture/Compare 1 interrupt enable
+            if sr.ccif(1) && dier.ccie(1) {
+                // Capture/compare 1 interrupt flag & Capture/Compare 1 interrupt enable
                 self.trigger_alarm(cs);
             }
         })

--- a/src/usbhs/mod.rs
+++ b/src/usbhs/mod.rs
@@ -126,7 +126,7 @@ impl<T: Instance> interrupt::typelevel::Handler<T::WakeupInterrupt> for WakeupIn
 pub struct Driver<'d, T: Instance, const NR_EP: usize> {
     phantom: PhantomData<&'d T>,
     allocator: EndpointBufferAllocator<'d, NR_EP>,
-    next_ep_addr: u8,
+    allocated: [bool; MAX_NR_EP],
 }
 
 impl<'d, T: Instance, const NR_EP: usize> Driver<'d, T, NR_EP> {
@@ -184,35 +184,65 @@ impl<'d, T: Instance, const NR_EP: usize> Driver<'d, T, NR_EP> {
         Self {
             phantom: PhantomData,
             allocator,
-            // 0 is reserved for the control endpoint
-            next_ep_addr: 1,
+            allocated: [false; MAX_NR_EP],
         }
     }
 
-    fn alloc_ep_address(&mut self) -> u8 {
-        if self.next_ep_addr as usize >= MAX_NR_EP {
-            panic!("ep addr overflow")
-        }
-
-        let addr = self.next_ep_addr;
-        self.next_ep_addr += 1;
-        addr
+    fn find_free_ep_address(&self, _dir: Direction) -> Result<u8, EndpointAllocError> {
+        self.allocated
+            .iter()
+            .enumerate()
+            .skip(1) // Skip index 0 which is reserved for control endpoint
+            .find(|(_, &allocated)| !allocated)
+            .map(|(i, _)| i as u8)
+            .ok_or(EndpointAllocError)
     }
 
     fn alloc_endpoint<D: Dir>(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
         dir: Direction,
     ) -> Result<Endpoint<'d, T, D>, EndpointAllocError> {
-        let ep_addr = self.alloc_ep_address();
+        let addr = match ep_addr {
+            Some(addr) => {
+                // Use the provided endpoint address
+                if addr.direction() != dir {
+                    return Err(EndpointAllocError);
+                }
+
+                let ep_num = addr.index();
+                if ep_num >= MAX_NR_EP {
+                    return Err(EndpointAllocError);
+                }
+
+                // Check if this endpoint is already allocated
+                if self.allocated[ep_num] {
+                    return Err(EndpointAllocError);
+                }
+
+                self.allocated[ep_num] = true;
+                addr
+            }
+            None => {
+                // Find a free endpoint address
+                let ep_addr = self.find_free_ep_address(dir)?;
+                let addr = EndpointAddress::from_parts(ep_addr as usize, dir);
+
+                // Mark as allocated
+                self.allocated[ep_addr as usize] = true;
+
+                addr
+            }
+        };
+
         let data = self.allocator.alloc_endpoint(max_packet_size)?;
 
         Ok(Endpoint::new(
             EndpointInfo {
-                // todo fix in embassy usb driver ep_addr should be u8 with top bit unset
-                addr: EndpointAddress::from_parts(ep_addr as usize, dir),
+                addr,
                 ep_type,
                 max_packet_size,
                 interval_ms,
@@ -231,19 +261,21 @@ impl<'d, T: Instance, const NR_EP: usize> embassy_usb_driver::Driver<'d> for Dri
     fn alloc_endpoint_out(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
     ) -> Result<Self::EndpointOut, EndpointAllocError> {
-        self.alloc_endpoint(ep_type, max_packet_size, interval_ms, Direction::Out)
+        self.alloc_endpoint(ep_type, ep_addr, max_packet_size, interval_ms, Direction::Out)
     }
 
     fn alloc_endpoint_in(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
     ) -> Result<Self::EndpointIn, EndpointAllocError> {
-        self.alloc_endpoint(ep_type, max_packet_size, interval_ms, Direction::In)
+        self.alloc_endpoint(ep_type, ep_addr, max_packet_size, interval_ms, Direction::In)
     }
 
     fn start(mut self, control_max_packet_size: u16) -> (Self::Bus, Self::ControlPipe) {


### PR DESCRIPTION
feat(usb): Support manual endpoint address allocation
- Update embassy-usb-driver dependency to 0.2.0
- Replace sequential endpoint allocation with allocation tracking bitmap, which is required by the embassy-usb-driver 0.2.0 trait