### PR TITLE
Added dma for dac in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -469,6 +469,8 @@ fn main() {
         (("timer", "CH3"), quote!(crate::timer::Ch3Dma)),
         (("timer", "CH4"), quote!(crate::timer::Ch4Dma)),
         (("sdio", "SDIO"), quote!(crate::sdio::SdioDma)),
+        (("dac", "CH1"), quote!(crate::dac::DacDma1)),
+        (("dac", "CH2"), quote!(crate::dac::DacDma2)),
     ]
     .into();
 


### PR DESCRIPTION
In order to correctly define the DMA for DAC (and so the async write). It is necessary to add these two lines to build.rs, that simply define sealed traits. It should not brake anything