### PR TITLE
[enh] ADC: added PGA control on compatible devices

### DIFF
--- a/examples/ch32v203/src/bin/adc.rs
+++ b/examples/ch32v203/src/bin/adc.rs
@@ -6,7 +6,7 @@
 use ch32_hal as hal;
 use embassy_executor::Spawner;
 use embassy_time::{Delay, Duration, Timer};
-use hal::adc::SampleTime;
+use hal::adc::{SampleTime, Pga};
 use hal::gpio::{Level, Output};
 use hal::println;
 
@@ -33,7 +33,7 @@ async fn main(spawner: Spawner) -> ! {
         Timer::after(Duration::from_millis(500)).await;
 
         println!("Starting conversion!");
-        let val = adc.convert(&mut ch, SampleTime::CYCLES239_5);
+        let val = adc.convert(&mut ch, SampleTime::CYCLES239_5, Pga::X1);
 
         println!("val => {}", val);
     }

--- a/examples/ch32v305/src/bin/adc.rs
+++ b/examples/ch32v305/src/bin/adc.rs
@@ -6,7 +6,7 @@
 use ch32_hal as hal;
 use embassy_executor::Spawner;
 use embassy_time::{Delay, Duration, Timer};
-use hal::adc::SampleTime;
+use hal::adc::{SampleTime, Pga};
 use hal::gpio::{Level, Output};
 use hal::println;
 
@@ -32,7 +32,7 @@ async fn main(spawner: Spawner) -> ! {
         Timer::after(Duration::from_millis(500)).await;
 
         println!("Starting conversion!");
-        let val = adc.convert(&mut ch, SampleTime::CYCLES239_5);
+        let val = adc.convert(&mut ch, SampleTime::CYCLES239_5, Pga::X1);
 
         println!("val => {}", val);
     }

--- a/examples/ch32v307/src/bin/adc.rs
+++ b/examples/ch32v307/src/bin/adc.rs
@@ -6,7 +6,7 @@
 use ch32_hal as hal;
 use embassy_executor::Spawner;
 use embassy_time::{Delay, Duration, Timer};
-use hal::adc::SampleTime;
+use hal::adc::{SampleTime, Pga};
 use hal::gpio::{Level, Output};
 use hal::println;
 
@@ -33,7 +33,7 @@ async fn main(spawner: Spawner) -> ! {
         Timer::after(Duration::from_millis(500)).await;
 
         println!("Starting conversion!");
-        let val = adc.convert(&mut ch, SampleTime::CYCLES239_5);
+        let val = adc.convert(&mut ch, SampleTime::CYCLES239_5,  Pga::X1);
 
         println!("val => {}", val);
     }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -90,8 +90,11 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().ctlr2().modify(|w| w.set_adon(true));
 
         // start self-calibration
-        T::regs().ctlr2().modify(|w| w.set_rstcal(true));
-        while T::regs().ctlr2().read().rstcal() {} // wait for calibration to be done
+        #[cfg(any(adc_v1, adc_v3))]
+        {
+            T::regs().ctlr2().modify(|w| w.set_rstcal(true));
+            while T::regs().ctlr2().read().rstcal() {} // wait for calibration to be done
+        }
 
         Self { adc }
     }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -7,7 +7,7 @@ use core::marker::PhantomData;
 use embassy_sync::waitqueue::AtomicWaker;
 
 use crate::pac::adc::vals;
-#[cfg(any(adc_v1, adc_v3))]
+#[cfg(adc_v3)]
 pub use crate::pac::adc::vals::Pga;
 pub use crate::pac::adc::vals::SampleTime;
 use crate::{into_ref, peripherals, Peripheral};
@@ -97,7 +97,7 @@ impl<'d, T: Instance> Adc<'d, T> {
     }
 
     // regular conversion
-    #[cfg(any(adc_v1, adc_v3))]
+    #[cfg(adc_v3)]
     pub fn configure_channel(&mut self, channel: &mut impl AdcChannel<T>, rank: u8, sample_time: SampleTime, pga: Pga) {
         channel.set_as_analog();
 
@@ -137,7 +137,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         }
     }
 
-    #[cfg(not(any(adc_v1, adc_v3)))]
+    #[cfg(not(adc_v3))]
     pub fn configure_channel(&mut self, channel: &mut impl AdcChannel<T>, rank: u8, sample_time: SampleTime) {
         channel.set_as_analog();
 
@@ -170,7 +170,7 @@ impl<'d, T: Instance> Adc<'d, T> {
     }
 
     // Get_ADC_Val
-    #[cfg(any(adc_v1, adc_v3))]
+    #[cfg(adc_v3)]
     pub fn convert(&mut self, channel: &mut impl AdcChannel<T>, sample_time: SampleTime, pga: Pga) -> u16 {
         self.configure_channel(channel, 1, sample_time, pga);
 
@@ -182,7 +182,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().rdatar().read().data()
     }
 
-    #[cfg(not(any(adc_v1, adc_v3)))]
+    #[cfg(not(adc_v3))]
     pub fn convert(&mut self, channel: &mut impl AdcChannel<T>, sample_time: SampleTime) -> u16 {
         self.configure_channel(channel, 1, sample_time);
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -92,8 +92,10 @@ impl<'d, T: Instance> Adc<'d, T> {
         // start self-calibration
         #[cfg(any(adc_v1, adc_v3))]
         {
-            T::regs().ctlr2().modify(|w| w.set_rstcal(true));
-            while T::regs().ctlr2().read().rstcal() {} // wait for calibration to be done
+            T::regs().ctlr2().modify(|w| w.set_rstcal(true)); // reset calibration
+            while T::regs().ctlr2().read().rstcal() {}
+            T::regs().ctlr2().modify(|w| w.set_cal(true)); // start calibration
+            while T::regs().ctlr2().read().cal() {} // wait for calibration to be done
         }
 
         Self { adc }


### PR DESCRIPTION
Some members of the CH32 range have a built-in Programmable Gain Amplifier integrated into their ADC.

I tested it on the CH32V203, and all 4 settings (X1 to X64) work.
However, only X1 and X4 seem to have an accurate gain while the rest has pretty large deviations.

For the ADC that don't have a PGA the API remains identical, but for those who do the API is changed slightly with the addition of the PGA setting to the `.convert()` function.