### PR TITLE
Fix creating UART in half-duplex mode

### DIFF
--- a/src/usart/mod.rs
+++ b/src/usart/mod.rs
@@ -871,7 +871,10 @@ impl<'d, T: Instance> Uart<'d, T, Async> {
         rx_dma: Peri<'d, impl RxDma<T>>,
         mut config: Config,
     ) -> Result<Self, ConfigError> {
+        #[cfg(not(gpio_x0))]
         tx.set_as_af_output(AFType::OutputOpenDrain, Speed::High);
+        #[cfg(gpio_x0)]
+        tx.set_as_af_output(AFType::OutputPushPull, Speed::High);
         T::set_remap(REMAP);
 
         config.half_duplex = true;
@@ -945,7 +948,10 @@ impl<'d, T: Instance> Uart<'d, T, Blocking> {
         tx: Peri<'d, impl TxPin<T, REMAP>>,
         mut config: Config,
     ) -> Result<Self, ConfigError> {
+        #[cfg(not(gpio_x0))]
         tx.set_as_af_output(AFType::OutputOpenDrain, Speed::High);
+        #[cfg(gpio_x0)]
+        tx.set_as_af_output(AFType::OutputPushPull, Speed::High);
         T::set_remap(REMAP);
 
         config.half_duplex = true;

--- a/src/usart/mod.rs
+++ b/src/usart/mod.rs
@@ -867,14 +867,25 @@ impl<'d, T: Instance> Uart<'d, T, Async> {
     pub fn new_half_duplex<const REMAP: u8>(
         _peri: Peri<'d, T>,
         tx: Peri<'d, impl TxPin<T, REMAP>>,
+        tx_dma: Peri<'d, impl TxDma<T>>,
+        rx_dma: Peri<'d, impl RxDma<T>>,
         mut config: Config,
     ) -> Result<Self, ConfigError> {
-        tx.set_as_af_output(AFType::OutputPushPull, Speed::High);
+        tx.set_as_af_output(AFType::OutputOpenDrain, Speed::High);
         T::set_remap(REMAP);
 
         config.half_duplex = true;
 
-        Self::new_inner(_peri, None, Some(tx.into()), None, None, None, None, config)
+        Self::new_inner(
+            _peri,
+            None,
+            Some(tx.into()),
+            None,
+            None,
+            new_dma!(tx_dma),
+            new_dma!(rx_dma),
+            config
+        )
     }
 }
 
@@ -934,7 +945,7 @@ impl<'d, T: Instance> Uart<'d, T, Blocking> {
         tx: Peri<'d, impl TxPin<T, REMAP>>,
         mut config: Config,
     ) -> Result<Self, ConfigError> {
-        tx.set_as_af_output(AFType::OutputPushPull, Speed::High);
+        tx.set_as_af_output(AFType::OutputOpenDrain, Speed::High);
         T::set_remap(REMAP);
 
         config.half_duplex = true;


### PR DESCRIPTION
Currently, async `Uart` in half-duplex mode always hangs on `.read(...).await` due to an `.unwrap()` on `None` in `self.rx_dma` ([here](https://github.com/ch32-rs/ch32-hal/blob/83b7e6f76d810da430ad7a681495b7ef56c6dfdf/src/usart/mod.rs#L495)). This PR adds initialization of `tx_dma` and `rx_dma` into `new_half_duplex` (which does require changing the signature of that func, but making it more similar to other async uart init functions)

Also, for both blocking and async half-duplex initializations, the TX pin mode is changed from push-pull to open drain. This seems more appropriate, as open-drain better handles conflicts when multiple devices try to send bits on the shared line at the same. Also, this pin mode is suggested for UART half-duplex in the Reference Manual (at least for the CH32V003)