### PR TITLE
feat: add support for CH643 series

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           - ch32v307vct6
           - ch32x035f7p6
           - ch641
+          - ch643
         include:
           - chip: ch32l103f8u6
             target: riscv32imc-unknown-none-elf
@@ -54,6 +55,8 @@ jobs:
             target: riscv32imc-unknown-none-elf
           - chip: ch641
             target: riscv32i-unknown-none-elf
+          - chip: ch643
+            target: riscv32imc-unknown-none-elf
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -87,6 +90,7 @@ jobs:
           - ch32v307
           - ch32x035
           - ch641
+          - ch643
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,4 @@ ch32x035g8r6 = ["ch32-metapac/ch32x035g8r6", "qingke-rt/v4"]
 ch32x035g8u6 = ["ch32-metapac/ch32x035g8u6", "qingke-rt/v4"]
 ch32x035r8t6 = ["ch32-metapac/ch32x035r8t6", "qingke-rt/v4"]
 ch641 = ["ch32-metapac/ch641", "qingke-rt/v2"]
-
-# TODO
-# ch643 = []
+ch643 = ["ch32-metapac/ch643", "qingke-rt/v4"]

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ For a full list of chip capabilities and peripherals, check the [ch32-data](http
 
 | Family      | V2/V3  | V1  | V0  | X0  | L1  | CH641  | CH643  |
 |-------------|--------|-----|-----|-----|-----|--------|--------|
-| Embassy     | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |        |
+| Embassy     | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |  ✅   |
 | RCC         | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |  ✅   |
-| GPIO        | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |        |
+| GPIO        | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |  ✅    |
 | UART*       | ✅     | ✅  | ✅ | ✅  | ✅   | ❓      |        |
 | SPI*        | ✅     | ✅  | ✅ | ✅  | ✅   | N/A    |        |
 | I2C         | ✅     | ✅  | ✅ | ❓  | ❓   | ❓      |        |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For a full list of chip capabilities and peripherals, check the [ch32-data](http
 | SPI*        | ✅     | ✅  | ✅ | ✅  | ✅   | N/A    |        |
 | I2C         | ✅     | ✅  | ✅ | ❓  | ❓   | ❓      |        |
 | ADC         | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |        |
-| Timer(PWM)  | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |        |
+| Timer(PWM)  | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |  ✅   |
 | USBD        | ✅*    | N/A  | N/A  | N/A  | N/A   | N/A      |        |
 | USB/OTG FS  | ✅*    | N/A  | N/A  | N/A  | N/A   | N/A      |        |
 | USB HS      | ✅*    | N/A  | N/A  | N/A  | N/A   | N/A      |        |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For a full list of chip capabilities and peripherals, check the [ch32-data](http
 | UART*       | ✅     | ✅  | ✅ | ✅  | ✅   | ❓      |        |
 | SPI*        | ✅     | ✅  | ✅ | ✅  | ✅   | N/A    |        |
 | I2C         | ✅     | ✅  | ✅ | ❓  | ❓   | ❓      |        |
-| ADC         | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |        |
+| ADC         | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |  ✅   |
 | Timer(PWM)  | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |  ✅   |
 | USBD        | ✅*    | N/A  | N/A  | N/A  | N/A   | N/A      |        |
 | USB/OTG FS  | ✅*    | N/A  | N/A  | N/A  | N/A   | N/A      |        |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For a full list of chip capabilities and peripherals, check the [ch32-data](http
 | Family      | V2/V3  | V1  | V0  | X0  | L1  | CH641  | CH643  |
 |-------------|--------|-----|-----|-----|-----|--------|--------|
 | Embassy     | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |        |
-| RCC         | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |        |
+| RCC         | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |  ✅   |
 | GPIO        | ✅     | ✅  | ✅ | ✅  | ✅   | ✅      |        |
 | UART*       | ✅     | ✅  | ✅ | ✅  | ✅   | ❓      |        |
 | SPI*        | ✅     | ✅  | ✅ | ✅  | ✅   | N/A    |        |

--- a/examples/ch643/.cargo/config.toml
+++ b/examples/ch643/.cargo/config.toml
@@ -1,0 +1,11 @@
+[build]
+target = "riscv32imc-unknown-none-elf"
+
+[target.riscv32imc-unknown-none-elf]
+runner = "wlink flash --enable-sdi-print --watch-serial"
+# runner = "wlink -v flash"
+
+# Use the following or build.rs
+#rustflags = [
+#  "-C", "link-arg=-Tlink.x",
+#]

--- a/examples/ch643/Cargo.toml
+++ b/examples/ch643/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "ch643-examples"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ch32-hal = { path = "../../", features = [
+    "ch643",
+    "memory-x",
+    "embassy",
+    "rt",
+] }
+embassy-executor = { version = "0.9.1", features = [
+    "arch-spin",
+    "executor-thread",
+] }
+embassy-time = "0.5.0"
+
+qingke-rt = "0.6.1"
+qingke = "0.6.1"
+
+panic-halt = "1.0"
+
+embedded-hal = "1.0.0"
+heapless = "0.8.0"
+
+[profile.release]
+strip = false   # symbols are not flashed to the microcontroller, so don't strip them.
+lto = true
+opt-level = "z" # Optimize for size.

--- a/examples/ch643/Cargo.toml
+++ b/examples/ch643/Cargo.toml
@@ -16,8 +16,8 @@ embassy-executor = { version = "0.9.1", features = [
 ] }
 embassy-time = "0.5.0"
 
-qingke-rt = "0.6.1"
-qingke = "0.6.1"
+qingke-rt = "0.7"
+qingke = "0.7"
 
 panic-halt = "1.0"
 

--- a/examples/ch643/README.md
+++ b/examples/ch643/README.md
@@ -1,0 +1,10 @@
+# ch643-examples
+
+## Boards
+
+### CH643-Pico
+
+Link: <https://github.com/WayneWu3/CH643-Pico.git>
+
+- MCU: CH643Q
+- LED: PB17

--- a/examples/ch643/build.rs
+++ b/examples/ch643/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    //println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    // println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/examples/ch643/src/bin/adc.rs
+++ b/examples/ch643/src/bin/adc.rs
@@ -1,0 +1,31 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
+
+use hal::delay::Delay;
+use hal::gpio::{Level, Output};
+use hal::adc::SampleTime;
+use hal::println;
+use {ch32_hal as hal, panic_halt as _};
+
+#[qingke_rt::entry]
+fn main() -> ! {
+    //hal::debug::SDIPrint::enable();
+    let p = hal::init(Default::default());
+
+    let mut delay = Delay;
+
+    let mut led = Output::new(p.PB17, Level::Low, Default::default());
+
+    let mut adc = hal::adc::Adc::new(p.ADC1, Default::default());
+    let mut pin = p.PA1;
+
+    loop {
+        led.toggle();
+        delay.delay_ms(1000);
+
+        let val = adc.convert(&mut pin, SampleTime::CYCLES9);
+        println!("adc: {}", val);
+    }
+}

--- a/examples/ch643/src/bin/blinky.rs
+++ b/examples/ch643/src/bin/blinky.rs
@@ -1,0 +1,26 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
+
+use hal::delay::Delay;
+use hal::gpio::{Level, Output};
+use {ch32_hal as hal, panic_halt as _};
+
+#[qingke_rt::entry]
+fn main() -> ! {
+    hal::debug::SDIPrint::enable();
+    let p = hal::init(Default::default());
+
+    let mut delay = Delay;
+
+    let mut led = Output::new(p.PB17, Level::Low, Default::default());
+    loop {
+        led.toggle();
+
+        delay.delay_ms(500);
+        hal::println!("toggle!");
+        let val = hal::pac::SYSTICK.cnt().read();
+        hal::println!("systick: {}", val);
+    }
+}

--- a/examples/ch643/src/bin/embassy_blinky.rs
+++ b/examples/ch643/src/bin/embassy_blinky.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
+
+use ch32_hal as hal;
+use hal::Peri;
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::println;
+
+#[embassy_executor::task(pool_size = 2)]
+async fn blink(pin: Peri<'static, AnyPin>, interval_ms: u64) {
+    let mut led = Output::new(pin, Level::Low, Default::default());
+
+    loop {
+        led.set_high();
+        Timer::after_millis(interval_ms).await;
+        led.set_low();
+        Timer::after_millis(interval_ms).await;
+    }
+}
+
+#[embassy_executor::main(entry = "qingke_rt::entry")]
+async fn main(spawner: Spawner) -> ! {
+    hal::debug::SDIPrint::enable();
+    let mut config = hal::Config::default();
+    config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSI;
+    let p = hal::init(config);
+
+    println!("CHIP signature => {}", hal::signature::chip_id().name());
+    println!("Clocks {:?}", hal::rcc::clocks());
+
+    // let mut led = Output::new(p.PB17, Level::Low, Default::default());
+
+    spawner.spawn(blink(p.PB17.into(), 500)).unwrap();
+
+    loop {
+        Timer::after_millis(1000).await;
+        println!("tick");
+    }
+}
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    let _ = hal::println!("\n\n\n{}", info);
+
+    loop {}
+}

--- a/examples/ch643/src/bin/pwm.rs
+++ b/examples/ch643/src/bin/pwm.rs
@@ -1,0 +1,43 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
+
+use hal::delay::Delay;
+use hal::time::Hertz;
+use hal::timer::low_level::CountingMode;
+use hal::timer::simple_pwm::{PwmPin, SimplePwm};
+use {ch32_hal as hal, panic_halt as _};
+
+#[qingke_rt::entry]
+fn main() -> ! {
+    hal::debug::SDIPrint::enable();
+    let p = hal::init(Default::default());
+
+    let pin = PwmPin::new_ch1::<0>(p.PB9);
+    let ch = hal::timer::Channel::Ch1;
+    let mut pwm = SimplePwm::new(
+        p.TIM1,
+        Some(pin),
+        None,
+        None,
+        None,
+        Hertz::khz(1),
+        CountingMode::default(),
+    );
+
+    let _max_duty = pwm.get_max_duty();
+    pwm.set_duty(ch, 2000);
+    pwm.enable(ch);
+
+    loop {
+        for i in 0..100 {
+            pwm.set_duty(ch, i * 80);
+            Delay.delay_ms(1_0);
+        }
+        for i in (0..100).rev() {
+            pwm.set_duty(ch, i * 80);
+            Delay.delay_ms(1_0);
+        }
+    }
+}

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -48,7 +48,7 @@ mod _exti_8lines {
     impl_exti!(EXTI7, 7);
 }
 
-#[cfg(not(any(ch32v0, ch32m0, ch643)))]
+#[cfg(not(any(ch32v0, ch32m0)))]
 mod _exti_16lines {
     use super::*;
 

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -48,7 +48,7 @@ mod rcc_impl;
 #[path = "v3.rs"]
 mod rcc_impl;
 
-#[cfg(ch32x0)]
+#[cfg(any(ch32x0, ch643))]
 #[path = "x0.rs"]
 mod rcc_impl;
 


### PR DESCRIPTION
# Description
Adds initial support for the **WCH CH643** series.

**Dependency Note:**
This PR relies on [ch32-rs/ch32-data#23](https://github.com/ch32-rs/ch32-data/pull/23) (adds missing `PIOC` interrupt). 

Since `ch32-metapac` is generated from `ch32-data`, I verified this by locally generating the metapac with the patched data. This PR **does not** include those generated files; it's ready to merge once upstream `ch32-data` is updated and released.

# Changes
*   Mapped CH643 to use the `x0` RCC implementation.
*   Enabled 16-line EXTI support in `src/exti.rs`.
*   Registered the `ch643` feature in `Cargo.toml` and updated documentation.
*   Added verification examples under `examples/ch643`: basic blinky, embassy (async/clock tree), PWM, and ADC.

# Hardware Verification
All tests were performed on a CH643 development board using wlink for flashing and SDI logging.
## Blinky
- The onboard LED (PB17) toggles correctly at 500ms intervals using blocking delay, and Systick counts increment as expected in the logs.

```bash
$ cargo +nightly run --release --bin blinky
......
    Finished `release` profile [optimized] target(s) in 0.34s
     Running `wlink flash --enable-sdi-print --watch-serial target/riscv32imc-unknown-none-elf/release/blinky`
11:39:50 [INFO] Connected to WCH-Link v2.14(v34) (WCH-LinkE-CH32V305)
11:39:50 [INFO] Attached chip: CH643 (ChipID: 0x64310621)
11:39:50 [INFO] Chip ESIG: FlashSize(62KB) UID(cd-ab-be-d5-4d-bc-d8-3d)
11:39:50 [INFO] Flash protected: false
11:39:50 [INFO] Read target/riscv32imc-unknown-none-elf/release/blinky as ELF format
11:39:50 [INFO] Flashing 5692 bytes to 0x08000000
█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 5692/569211:39:50 [INFO] Flash done
11:39:51 [INFO] Now reset...
11:39:51 [INFO] Now connect to the WCH-Link serial port to read SDI print
2026-01-22 19:39:51.958: toggle!
2026-01-22 19:39:51.959: systick: 4000012
2026-01-22 19:39:52.460: toggle!
2026-01-22 19:39:52.461: systick: 4000013
2026-01-22 19:39:52.962: toggle!
2026-01-22 19:39:52.963: systick: 4000016
2026-01-22 19:39:53.464: toggle!
2026-01-22 19:39:53.465: systick: 4000013
2026-01-22 19:39:53.966: toggle!
2026-01-22 19:39:53.967: systick: 4000016
```

## Embassy Blinky
- Configured to 48MHz HSI. Confirmed that the async LED task and main loop run concurrently with accurate timing, verifying the clock tree setup.

```bash
$ cargo +nightly run --release --bin embassy_blinky
......
    Finished `release` profile [optimized] target(s) in 0.47s
     Running `wlink flash --enable-sdi-print --watch-serial target/riscv32imc-unknown-none-elf/release/embassy_blinky`
11:42:48 [INFO] Connected to WCH-Link v2.14(v34) (WCH-LinkE-CH32V305)
11:42:48 [INFO] Attached chip: CH643 (ChipID: 0x64310621)
11:42:48 [INFO] Chip ESIG: FlashSize(62KB) UID(cd-ab-be-d5-4d-bc-d8-3d)
11:42:48 [INFO] Flash protected: false
11:42:48 [INFO] Read target/riscv32imc-unknown-none-elf/release/embassy_blinky as ELF format
11:42:48 [INFO] Flashing 14240 bytes to 0x08000000
███████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 14240/1424011:42:49 [INFO] Flash done
11:42:49 [INFO] Now reset...
11:42:49 [INFO] Now connect to the WCH-Link serial port to read SDI print
2026-01-22 19:42:49.864: 0), hclk: Hertz(48000000), pclk1: Hertz(48000000), pclk2: Hertz(48000000), pclk1_tim: Hertz(48000000), pclk2_tim: Hertz(48000000) }
2026-01-22 19:42:50.881: tick
2026-01-22 19:42:51.882: tick
2026-01-22 19:42:52.883: tick
```

## PWM
- Verified via oscilloscope; the waveform duty cycle cycles smoothly between min and max as expected.

```bash
$ cargo +nightly run --release --bin pwm
......
    Finished `release` profile [optimized] target(s) in 0.06s
     Running `wlink flash --enable-sdi-print --watch-serial target/riscv32imc-unknown-none-elf/release/pwm`
11:45:18 [INFO] Connected to WCH-Link v2.14(v34) (WCH-LinkE-CH32V305)
11:45:18 [INFO] Attached chip: CH643 (ChipID: 0x64310621)
11:45:18 [INFO] Chip ESIG: FlashSize(62KB) UID(cd-ab-be-d5-4d-bc-d8-3d)
11:45:18 [INFO] Flash protected: false
11:45:18 [INFO] Read target/riscv32imc-unknown-none-elf/release/pwm as ELF format
11:45:18 [INFO] Flashing 2616 bytes to 0x08000000
█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 2616/261611:45:18 [INFO] Flash done
11:45:19 [INFO] Now reset...
11:45:19 [INFO] Now connect to the WCH-Link serial port to read SDI print
```

## ADC
- Verified using a square wave (1V/2V) generated by an STM32 DAC. The log output accurately reflects the input, alternating between approx. 1240 (1V) and 2460 (2V) in real-time.

```bash
$ cargo +nightly run --release --bin adc
......
    Finished `release` profile [optimized] target(s) in 0.08s
     Running `wlink flash --enable-sdi-print --watch-serial target/riscv32imc-unknown-none-elf/release/adc`
12:04:40 [INFO] Connected to WCH-Link v2.14(v34) (WCH-LinkE-CH32V305)
12:04:40 [INFO] Attached chip: CH643 (ChipID: 0x64310621)
12:04:40 [INFO] Chip ESIG: FlashSize(62KB) UID(cd-ab-be-d5-4d-bc-d8-3d)
12:04:40 [INFO] Flash protected: false
12:04:40 [INFO] Read target/riscv32imc-unknown-none-elf/release/adc as ELF format
12:04:40 [INFO] Flashing 4624 bytes to 0x08000000
█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 4624/462412:04:41 [INFO] Flash done
12:04:41 [INFO] Now reset...
12:04:41 [INFO] Now connect to the WCH-Link serial port to read SDI print
2026-01-22 20:04:42.524: adc: 1223
2026-01-22 20:04:43.526: adc: 1247
2026-01-22 20:04:44.527: adc: 1248
2026-01-22 20:04:45.528: adc: 1243
2026-01-22 20:04:46.529: adc: 2451
2026-01-22 20:04:47.531: adc: 2467
2026-01-22 20:04:48.532: adc: 2467
2026-01-22 20:04:49.533: adc: 1233
2026-01-22 20:04:50.533: adc: 2448
2026-01-22 20:04:51.534: adc: 2467
2026-01-22 20:04:52.535: adc: 1231
2026-01-22 20:04:53.537: adc: 1247
```