### PR TITLE
fix(i2c): Set i2c pins as pushpull on CH32X035

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -425,7 +425,7 @@ pub enum OutputType {
     /// Drive the pin both high or low.
     PushPull,
     /// Drive the pin low, or don't drive it at all if the output level is high.
-    #[cfg(not(gpio_x0))]
+    #[cfg(not(gpio_x0))] // CH32X0 do not support OpenDrain on gpios (except for i2c pins when i2c is enabled)
     OpenDrain,
 }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -155,8 +155,15 @@ impl<'d, T: Instance, M: Mode> I2c<'d, T, M> {
 
         T::set_remap(REMAP);
 
+        #[cfg(not(gpio_x0))]
         scl.set_as_af_output(AFType::OutputOpenDrain, Speed::High);
+        #[cfg(not(gpio_x0))]
         sda.set_as_af_output(AFType::OutputOpenDrain, Speed::High);
+        // CH32X0 does not have open-drain mode, except for I2C pins when i2c is enabled.
+        #[cfg(gpio_x0)]
+        scl.set_as_af_output(AFType::OutputPushPull, Speed::High);
+        #[cfg(gpio_x0)]
+        sda.set_as_af_output(AFType::OutputPushPull, Speed::High);
 
         unsafe { T::EventInterrupt::enable() };
         unsafe { T::ErrorInterrupt::enable() };


### PR DESCRIPTION
CH32X035 does not support configuring the gpios in open drain mode.
When activating the i2c peripheral it will automaticcaly configure the pins
as opendrain if set to alternate function
