### PR TITLE
More USB PD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For a full list of chip capabilities and peripherals, check the [ch32-data](http
 | USBD        | ✅*    | N/A  | N/A  | N/A  | N/A   | N/A      |        |
 | USB/OTG FS  | ✅*    | N/A  | N/A  | N/A  | N/A   | N/A      |        |
 | USB HS      | ✅*    | N/A  | N/A  | N/A  | N/A   | N/A      |        |
+| USB PD      | N/A    | N/A  | N/A  | ✅*  | ✅*   | ❓        | ❓     |
 | CAN*        | ✅     |     |   |     | ✅ |          |        |
 
 

--- a/examples/ch32l103/Cargo.toml
+++ b/examples/ch32l103/Cargo.toml
@@ -24,6 +24,8 @@ qingke-rt = "0.6.1"
 panic-halt = "1.0"
 embedded-hal = "1.0.0"
 embedded-can = "0.4.1"
+usbpd = "2.0.0"
+usbpd-traits = "2.0.0"
 
 [profile.release]
 strip = false   # symbols are not flashed to the microcontroller, so don't strip them.

--- a/examples/ch32l103/src/bin/usbpd.rs
+++ b/examples/ch32l103/src/bin/usbpd.rs
@@ -132,7 +132,8 @@ async fn main(_spawner: Spawner) {
     config.rcc = hal::rcc::Config::SYSCLK_FREQ_96MHZ_HSE;
     let p = hal::init(config);
 
-    let mut phy = UsbPdPhy::new_async(p.USBPD, p.PB6, p.PB7, Irq).unwrap();
+    let mut phy = UsbPdPhy::new_async(p.USBPD, p.PB6, p.PB7, Irq);
+    phy.detect_cc().unwrap();
 
     let device = Device {};
     let driver = UsbpdSinkDriver::new(phy);

--- a/examples/ch32l103/src/bin/usbpd.rs
+++ b/examples/ch32l103/src/bin/usbpd.rs
@@ -1,0 +1,146 @@
+#![no_std]
+#![no_main]
+
+use ch32_hal as hal;
+use ch32_hal::println;
+use ch32_hal::usbpd::{Error as UsbpdError, InterruptHandler, Sop, UsbPdPhy};
+use ch32_hal::{bind_interrupts, peripherals};
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use panic_halt as _;
+use usbpd::protocol_layer::message::data::request::{self, CurrentRequest, VoltageRequest};
+use usbpd::protocol_layer::message::data::source_capabilities::SourceCapabilities;
+use usbpd::sink::device_policy_manager::{DevicePolicyManager, Event};
+use usbpd::sink::policy_engine::Sink;
+use usbpd::timers::Timer as SinkTimer;
+use usbpd_traits::Driver as SinkDriver;
+
+bind_interrupts!(
+    struct Irq {
+        USBPD => InterruptHandler<peripherals::USBPD>;
+    }
+);
+
+fn print_source_capability(pdo: &usbpd::protocol_layer::message::data::source_capabilities::PowerDataObject) {
+    match pdo {
+        usbpd::protocol_layer::message::data::source_capabilities::PowerDataObject::FixedSupply(fixed) => {
+            println!(
+                "PDO: Fixed - {} mV, {} mA",
+                fixed.voltage().value,
+                fixed.max_current().value
+            );
+        }
+        usbpd::protocol_layer::message::data::source_capabilities::PowerDataObject::VariableSupply(variable) => {
+            println!(
+                "PDO: Variable - {}-{} mV, {} mA",
+                variable.min_voltage().value,
+                variable.max_voltage().value,
+                variable.max_current().value
+            );
+        }
+        usbpd::protocol_layer::message::data::source_capabilities::PowerDataObject::Augmented(augmented) => {
+            match augmented {
+                usbpd::protocol_layer::message::data::source_capabilities::Augmented::Spr(pps) => {
+                    println!(
+                        "PDO: PPS - {}-{} mV, {} mA",
+                        pps.min_voltage().value,
+                        pps.max_voltage().value,
+                        pps.max_current().value
+                    );
+                }
+                _ => println!("PDO: Augmented - Other"),
+            }
+        }
+        _ => println!("PDO: Other"),
+    }
+}
+
+struct EmbassySinkTimer {}
+
+impl SinkTimer for EmbassySinkTimer {
+    async fn after_millis(milliseconds: u64) {
+        Timer::after_millis(milliseconds).await
+    }
+}
+
+struct UsbpdSinkDriver<'d> {
+    usbpd: UsbPdPhy<'d, peripherals::USBPD, hal::mode::Async>,
+}
+
+impl<'d> UsbpdSinkDriver<'d> {
+    fn new(usbpd: UsbPdPhy<'d, peripherals::USBPD, hal::mode::Async>) -> Self {
+        Self { usbpd }
+    }
+}
+
+impl SinkDriver for UsbpdSinkDriver<'_> {
+    async fn wait_for_vbus(&mut self) {
+        // The sink policy engine is only running when attached. Therefore VBus is present.
+    }
+
+    async fn receive(&mut self, buffer: &mut [u8]) -> Result<usize, usbpd_traits::DriverRxError> {
+        match self.usbpd.receive(buffer).await {
+            Ok((Sop::Sop, size)) => Ok(size),
+            Ok(_) => Err(usbpd_traits::DriverRxError::Discarded),
+            Err(e) => match e {
+                UsbpdError::HardReset => Err(usbpd_traits::DriverRxError::HardReset),
+                UsbpdError::Rejected => Err(usbpd_traits::DriverRxError::Discarded),
+                _ => Err(usbpd_traits::DriverRxError::Discarded),
+            },
+        }
+    }
+
+    async fn transmit(&mut self, data: &[u8]) -> Result<(), usbpd_traits::DriverTxError> {
+        self.usbpd.transmit(data).await;
+        Ok(())
+    }
+
+    async fn transmit_hard_reset(&mut self) -> Result<(), usbpd_traits::DriverTxError> {
+        self.usbpd.transmit_hardreset().await;
+        Ok(())
+    }
+}
+
+struct Device {}
+
+impl DevicePolicyManager for Device {
+    async fn request(&mut self, source_capabilities: &SourceCapabilities) -> request::PowerSource {
+        request::PowerSource::new_fixed(
+            request::CurrentRequest::Highest,
+            request::VoltageRequest::Safe5V,
+            source_capabilities,
+        )
+        .unwrap()
+    }
+
+    async fn get_event(&mut self, source_capabilities: &SourceCapabilities) -> Event {
+        println!("DevicePolicyManager: Waiting for events...");
+        for (_, pdo) in source_capabilities.pdos().iter().enumerate() {
+            print_source_capability(pdo);
+        }
+        loop {
+            Timer::after_millis(1000).await;
+        }
+    }
+}
+
+#[embassy_executor::main(entry = "qingke_rt::entry")]
+async fn main(_spawner: Spawner) {
+    hal::debug::SDIPrint::enable();
+
+    let mut config = hal::Config::default();
+    config.rcc = hal::rcc::Config::SYSCLK_FREQ_96MHZ_HSE;
+    let p = hal::init(config);
+
+    let mut phy = UsbPdPhy::new_async(p.USBPD, p.PB6, p.PB7, Irq).unwrap();
+
+    let device = Device {};
+    let driver = UsbpdSinkDriver::new(phy);
+    let mut sink: Sink<_, EmbassySinkTimer, _> = Sink::new(driver, device);
+    println!("Starting USB-PD sink policy engine...");
+    let _ = sink.run().await;
+    println!("Sink policy engine exited unexpectedly");
+    loop {
+        Timer::after_millis(1000).await;
+    }
+}

--- a/examples/ch32x035/Cargo.toml
+++ b/examples/ch32x035/Cargo.toml
@@ -9,6 +9,7 @@ ch32-hal = { path = "../../", features = [
     "memory-x",
     "embassy",
     "rt",
+    "time-driver-tim2",
 ] }
 embassy-executor = { version = "0.9.1", features = [
     "arch-spin",
@@ -26,6 +27,8 @@ mipidsi = "0.7.1"
 embedded-graphics = "0.8.1"
 embedded-hal = "1.0.0"
 heapless = "0.8.0"
+usbpd = "2.0.0"
+usbpd-traits = "2.0.0"
 
 
 [profile.release]

--- a/examples/ch32x035/src/bin/usbpd.rs
+++ b/examples/ch32x035/src/bin/usbpd.rs
@@ -1,0 +1,146 @@
+#![no_std]
+#![no_main]
+
+use ch32_hal as hal;
+use ch32_hal::println;
+use ch32_hal::usbpd::{Error as UsbpdError, InterruptHandler, Sop, UsbPdPhy};
+use ch32_hal::{bind_interrupts, peripherals};
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use panic_halt as _;
+use usbpd::protocol_layer::message::data::request::{self, CurrentRequest, VoltageRequest};
+use usbpd::protocol_layer::message::data::source_capabilities::SourceCapabilities;
+use usbpd::sink::device_policy_manager::{DevicePolicyManager, Event};
+use usbpd::sink::policy_engine::Sink;
+use usbpd::timers::Timer as SinkTimer;
+use usbpd_traits::Driver as SinkDriver;
+
+bind_interrupts!(
+    struct Irq {
+        USBPD => InterruptHandler<peripherals::USBPD>;
+    }
+);
+
+fn print_source_capability(pdo: &usbpd::protocol_layer::message::data::source_capabilities::PowerDataObject) {
+    match pdo {
+        usbpd::protocol_layer::message::data::source_capabilities::PowerDataObject::FixedSupply(fixed) => {
+            println!(
+                "PDO: Fixed - {} mV, {} mA",
+                fixed.voltage().value,
+                fixed.max_current().value
+            );
+        }
+        usbpd::protocol_layer::message::data::source_capabilities::PowerDataObject::VariableSupply(variable) => {
+            println!(
+                "PDO: Variable - {}-{} mV, {} mA",
+                variable.min_voltage().value,
+                variable.max_voltage().value,
+                variable.max_current().value
+            );
+        }
+        usbpd::protocol_layer::message::data::source_capabilities::PowerDataObject::Augmented(augmented) => {
+            match augmented {
+                usbpd::protocol_layer::message::data::source_capabilities::Augmented::Spr(pps) => {
+                    println!(
+                        "PDO: PPS - {}-{} mV, {} mA",
+                        pps.min_voltage().value,
+                        pps.max_voltage().value,
+                        pps.max_current().value
+                    );
+                }
+                _ => println!("PDO: Augmented - Other"),
+            }
+        }
+        _ => println!("PDO: Other"),
+    }
+}
+
+struct EmbassySinkTimer {}
+
+impl SinkTimer for EmbassySinkTimer {
+    async fn after_millis(milliseconds: u64) {
+        Timer::after_millis(milliseconds).await
+    }
+}
+
+struct UsbpdSinkDriver<'d> {
+    usbpd: UsbPdPhy<'d, peripherals::USBPD, hal::mode::Async>,
+}
+
+impl<'d> UsbpdSinkDriver<'d> {
+    fn new(usbpd: UsbPdPhy<'d, peripherals::USBPD, hal::mode::Async>) -> Self {
+        Self { usbpd }
+    }
+}
+
+impl SinkDriver for UsbpdSinkDriver<'_> {
+    async fn wait_for_vbus(&mut self) {
+        // The sink policy engine is only running when attached. Therefore VBus is present.
+    }
+
+    async fn receive(&mut self, buffer: &mut [u8]) -> Result<usize, usbpd_traits::DriverRxError> {
+        match self.usbpd.receive(buffer).await {
+            Ok((Sop::Sop, size)) => Ok(size),
+            Ok(_) => Err(usbpd_traits::DriverRxError::Discarded),
+            Err(e) => match e {
+                UsbpdError::HardReset => Err(usbpd_traits::DriverRxError::HardReset),
+                UsbpdError::Rejected => Err(usbpd_traits::DriverRxError::Discarded),
+                _ => Err(usbpd_traits::DriverRxError::Discarded),
+            },
+        }
+    }
+
+    async fn transmit(&mut self, data: &[u8]) -> Result<(), usbpd_traits::DriverTxError> {
+        self.usbpd.transmit(data).await;
+        Ok(())
+    }
+
+    async fn transmit_hard_reset(&mut self) -> Result<(), usbpd_traits::DriverTxError> {
+        self.usbpd.transmit_hardreset().await;
+        Ok(())
+    }
+}
+
+struct Device {}
+
+impl DevicePolicyManager for Device {
+    async fn request(&mut self, source_capabilities: &SourceCapabilities) -> request::PowerSource {
+        request::PowerSource::new_fixed(
+            request::CurrentRequest::Highest,
+            request::VoltageRequest::Safe5V,
+            source_capabilities,
+        )
+        .unwrap()
+    }
+
+    async fn get_event(&mut self, source_capabilities: &SourceCapabilities) -> Event {
+        println!("DevicePolicyManager: Waiting for events...");
+        for (_, pdo) in source_capabilities.pdos().iter().enumerate() {
+            print_source_capability(pdo);
+        }
+        loop {
+            Timer::after_millis(1000).await;
+        }
+    }
+}
+
+#[embassy_executor::main(entry = "qingke_rt::entry")]
+async fn main(_spawner: Spawner) {
+    hal::debug::SDIPrint::enable();
+
+    let mut config = hal::Config::default();
+    config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSI;
+    let p = hal::init(config);
+
+    let mut phy = UsbPdPhy::new_async(p.USBPD, p.PC14, p.PC15, Irq).unwrap();
+
+    let device = Device {};
+    let driver = UsbpdSinkDriver::new(phy);
+    let mut sink: Sink<_, EmbassySinkTimer, _> = Sink::new(driver, device);
+    println!("Starting USB-PD sink policy engine...");
+    let _ = sink.run().await;
+    println!("Sink policy engine exited unexpectedly");
+    loop {
+        Timer::after_millis(1000).await;
+    }
+}

--- a/examples/ch32x035/src/bin/usbpd.rs
+++ b/examples/ch32x035/src/bin/usbpd.rs
@@ -132,7 +132,8 @@ async fn main(_spawner: Spawner) {
     config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSI;
     let p = hal::init(config);
 
-    let mut phy = UsbPdPhy::new_async(p.USBPD, p.PC14, p.PC15, Irq).unwrap();
+    let mut phy = UsbPdPhy::new_async(p.USBPD, p.PC14, p.PC15, Irq);
+    phy.detect_cc().unwrap();
 
     let device = Device {};
     let driver = UsbpdSinkDriver::new(phy);

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -70,7 +70,6 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 
         if status.if_rx_reset() {
             T::REGS.config().modify(|w| w.set_ie_rx_reset(false));
-            crate::println!("TODO: reset");
         }
 
         if status.buf_err() {
@@ -155,16 +154,16 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Async> {
             T::state().waker.register(cx.waker());
 
             if !T::REGS.config().read().ie_rx_reset() {
-                return Poll::Ready(());
+                return Poll::Ready(Err(Error::HardReset));
             }
 
             if !T::REGS.config().read().ie_rx_act() {
-                Poll::Ready(())
+                Poll::Ready(Ok(()))
             } else {
                 Poll::Pending
             }
         })
-        .await;
+        .await?;
         self.post_receive(buf)
     }
 
@@ -217,8 +216,17 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Blocking> {
 
         println!("begin blocking recv");
 
-        while !T::REGS.status().read().if_rx_act() {
-            // println!("wait");
+        loop {
+            let status = T::REGS.status().read();
+            if status.if_rx_act() {
+                break;
+            }
+            if status.if_rx_reset() {
+                unsafe {
+                    qingke::pfic::enable_interrupt(interrupt::USBPD.number() as _);
+                }
+                return Err(Error::HardReset);
+            }
         }
 
         unsafe {

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -215,16 +215,11 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
         });
     }
 
-    /// Receives a PD message into the provided buffer.
-    ///
-    /// Returns the number of received bytes or an error.
-    pub async fn receive(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+    /// Prepares the PHY for receiving a PD message into a buffer.
+    fn prepare_receive(&mut self, buf: &mut [u8]) {
         // set rx mode
-        // println!("before clear {}", T::REGS.status().read().0);
         T::REGS.config().modify(|w| w.set_pd_all_clr(true));
-        // println!("after clear0 {}", T::REGS.status().read().0);
         T::REGS.config().modify(|w| w.set_pd_all_clr(false));
-        //        println!("after clear1 {}", T::REGS.status().read().0);
 
         T::REGS.dma().write_value((buf.as_mut_ptr() as u32 & 0xFFFF) as u16);
 
@@ -233,60 +228,52 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
             .bmc_clk_cnt()
             .modify(|w| w.set_bmc_clk_cnt(calc_bmc_clk_for_rx()));
 
-        self.enable_rx_interrupt();
         T::REGS.control().modify(|w| w.set_bmc_start(true));
+    }
+
+    /// Decodes the received PD message and returns its length or an error.
+    fn post_receive(&mut self) -> Result<usize, Error> {
+        if T::REGS.status().read().if_rx_reset() {
+            return Err(Error::HardReset);
+        }
+        match T::REGS.status().read().bmc_aux() {
+            vals::BmcAux::SOP0 => Ok(T::REGS.bmc_byte_cnt().read().bmc_byte_cnt() as usize),
+            vals::BmcAux::SOP1 => Err(Error::HardReset),
+            _ => Err(Error::Rejected),
+        }
+    }
+
+    /// Receives a PD message into the provided buffer.
+    ///
+    /// Returns the number of received bytes or an error.
+    pub async fn receive(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        self.enable_rx_interrupt();
+        self.prepare_receive(buf);
 
         poll_fn(|cx| {
             T::state().waker.register(cx.waker());
 
             if !T::REGS.config().read().ie_rx_reset() {
-                return Poll::Ready(Err(Error::HardReset));
+                return Poll::Ready(());
             }
 
             if !T::REGS.config().read().ie_rx_act() {
-                match T::REGS.status().read().bmc_aux() {
-                    vals::BmcAux::SOP0 => {
-                        // println!("ctrl {}", T::REGS.control().read().0);
-                        // println!("=> {}", T::REGS.bmc_byte_cnt().read().bmc_byte_cnt());
-                        return Poll::Ready(Ok(T::REGS.bmc_byte_cnt().read().bmc_byte_cnt() as usize));
-                    }
-                    vals::BmcAux::SOP1 => {
-                        // hard reset
-                        return Poll::Ready(Err(Error::HardReset));
-                    }
-                    _ => {
-                        self.enable_rx_interrupt();
-                        return Poll::Pending;
-                    }
-                }
+                Poll::Ready(())
+            } else {
+                Poll::Pending
             }
-            Poll::Pending
         })
-        .await
+        .await;
+        self.post_receive()
     }
 
     pub fn blocking_receive(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
-        // set rx mode
-        // println!("before clear {}", T::REGS.status().read().0);
-        T::REGS.config().modify(|w| w.set_pd_all_clr(true));
-        // println!("after clear0 {}", T::REGS.status().read().0);
-        T::REGS.config().modify(|w| w.set_pd_all_clr(false));
-        //        println!("after clear1 {}", T::REGS.status().read().0);
-
-        T::REGS.dma().write_value((buf.as_mut_ptr() as u32 & 0xFFFF) as u16);
-
-        T::REGS.control().modify(|w| w.set_pd_tx_en(false)); // RX
-        T::REGS
-            .bmc_clk_cnt()
-            .modify(|w| w.set_bmc_clk_cnt(calc_bmc_clk_for_rx()));
-
-        self.enable_rx_interrupt();
         unsafe {
             qingke::pfic::disable_interrupt(interrupt::USBPD.number() as _);
         }
-        println!("begin blocking recv");
+        self.prepare_receive(buf);
 
-        T::REGS.control().modify(|w| w.set_bmc_start(true));
+        println!("begin blocking recv");
 
         while !T::REGS.status().read().if_rx_act() {
             // println!("wait");
@@ -295,10 +282,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
         unsafe {
             qingke::pfic::enable_interrupt(interrupt::USBPD.number() as _);
         }
-
-        let byte_cnt = T::REGS.bmc_byte_cnt().read().bmc_byte_cnt() as usize;
-
-        Ok(byte_cnt)
+        self.post_receive()
     }
 
     fn transmit(&mut self, sop: u8, buf: &[u8]) -> Result<(), Error> {

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -395,6 +395,7 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
         }
         let byte_count = T::REGS.bmc_byte_cnt().read().bmc_byte_cnt() as usize;
         let byte_count = byte_count.saturating_sub(4); // Strip the 4-byte CRC
+        let byte_count = byte_count.min(buf.len()).min(30); // Cap to buffer size and our internal buffer size
         buf[..byte_count].copy_from_slice(&self.buffer.to_slice()[..byte_count]);
         match T::REGS.status().read().bmc_aux() {
             vals::BmcAux::SOP0 => Ok((Sop::Sop, byte_count)),
@@ -415,7 +416,8 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
             T::REGS.dma().write_value(0);
         } else {
             // We use our own buffer to ensure it is 4-byte aligned, as required by the hardware.
-            self.buffer.data[..buf.len()].copy_from_slice(buf);
+            let len = buf.len().min(30);
+            self.buffer.data[..len].copy_from_slice(&buf[..len]);
             T::REGS.dma().write_value(self.buffer.address());
         }
 

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -210,7 +210,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
     fn enable_tx_interrupt(&mut self) {
         T::REGS.config().modify(|w| {
             w.set_ie_rx_act(false); // Receive completion interrupt disable
-            w.set_ie_rx_reset(true); // Receive reset interrupt enable
+            w.set_ie_rx_reset(false); // Receive reset interrupt disable
             w.set_ie_tx_end(true); // End-of-transmit interrupt enable
         });
     }

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -296,7 +296,9 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
             qingke::pfic::enable_interrupt(interrupt::USBPD.number() as _);
         }
 
-        Ok(10)
+        let byte_cnt = T::REGS.bmc_byte_cnt().read().bmc_byte_cnt() as usize;
+
+        Ok(byte_cnt)
     }
 
     fn transmit(&mut self, sop: u8, buf: &[u8]) -> Result<(), Error> {

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -28,7 +28,7 @@ pub enum Error {
     CCNotConnected,
     NotSupported,
     HardReset,
-    /// Unexpeted message type
+    /// Unexpected message type
     Protocol(u8),
     MaxRetry,
 }

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -103,6 +103,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
         });
         #[cfg(ch32l1)]
         afio.cr().modify(|w| {
+            // PD pin PB6/PD7 High threshold input mode.
             w.set_usbpd_in_hvt(true);
         });
 
@@ -111,7 +112,14 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
             //    w.set_pd_filt_en(true);
             //  w.set_pd_rst_en(true);
         });
-        T::REGS.status().write(|w| w.0 = 0b111111_00); // write 1 to clear
+        T::REGS.status().write(|w| {
+            w.set_if_tx_end(true);
+            w.set_if_rx_reset(true);
+            w.set_if_rx_act(true);
+            w.set_if_rx_byte(true);
+            w.set_if_rx_bit(true);
+            w.set_buf_err(true);
+        });
 
         // pd_phy_reset
 
@@ -135,7 +143,14 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
             w.set_pd_dma_en(true);
             //    w.set_pd_filt_en(true);
         });
-        T::REGS.status().write(|w| w.0 = 0b111111_00); // write 1 to clear
+        T::REGS.status().write(|w| {
+            w.set_if_tx_end(true);
+            w.set_if_rx_reset(true);
+            w.set_if_rx_act(true);
+            w.set_if_rx_byte(true);
+            w.set_if_rx_bit(true);
+            w.set_buf_err(true);
+        });
 
         T::port_cc_reg(self.cc1).modify(|w| w.set_cc_lve(false));
         T::port_cc_reg(self.cc2).modify(|w| w.set_cc_lve(false));
@@ -181,17 +196,17 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
 
     fn enable_rx_interrupt(&mut self) {
         T::REGS.config().modify(|w| {
-            w.set_ie_rx_act(true);
-            w.set_ie_rx_reset(true);
-            w.set_ie_tx_end(false);
+            w.set_ie_rx_act(true); // Receive completion interrupt enable
+            w.set_ie_rx_reset(true); // Receive reset interrupt enable
+            w.set_ie_tx_end(false); // End-of-transmit interrupt disable
         });
     }
 
     fn enable_tx_interrupt(&mut self) {
         T::REGS.config().modify(|w| {
-            w.set_ie_rx_act(false);
-            w.set_ie_rx_reset(true);
-            w.set_ie_tx_end(true);
+            w.set_ie_rx_act(false); // Receive completion interrupt disable
+            w.set_ie_rx_reset(true); // Receive reset interrupt enable
+            w.set_ie_tx_end(true); // End-of-transmit interrupt enable
         });
     }
 
@@ -297,7 +312,14 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
         T::REGS.bmc_tx_sz().write(|w| w.set_bmc_tx_sz(buf.len() as _));
         T::REGS.control().modify(|w| w.set_pd_tx_en(true)); // TX
 
-        T::REGS.status().write(|w| w.0 = 0b11111100);
+        T::REGS.status().write(|w| {
+            w.set_if_tx_end(true);
+            w.set_if_rx_reset(true);
+            w.set_if_rx_act(true);
+            w.set_if_rx_byte(true);
+            w.set_if_rx_bit(true);
+            w.set_buf_err(true);
+        });
 
         T::REGS.control().modify(|w| w.set_bmc_start(true));
 

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -227,6 +227,8 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Blocking> {
                 }
                 return Err(Error::HardReset);
             }
+            #[cfg(feature = "embassy")]
+            embassy_futures::yield_now();
         }
 
         unsafe {
@@ -242,7 +244,8 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Blocking> {
         self.transmit_inner(Sop::Sop, buf);
 
         while !T::REGS.status().read().if_tx_end() {
-            // println!("wait");
+            #[cfg(feature = "embassy")]
+            embassy_futures::yield_now();
         }
 
         T::port_cc_reg(vals::CcSel::CC1).modify(|w| w.set_cc_lve(false));

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -52,10 +52,10 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 
         let status = usbpd.status().read();
 
-        println!("irq 0x{:02x}", status.0);
+        // println!("irq 0x{:02x}", status.0);
 
         if status.if_tx_end() {
-            println!(">");
+            // println!(">");
             //         T::REGS.port_cc1().modify(|w| w.set_cc_lve(false));
             // T::REGS.port_cc2().modify(|w| w.set_cc_lve(false));
 

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -17,6 +17,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 use pac::InterruptNumber;
 
 use crate::gpio::Pull;
+use crate::mode::{Async, Blocking, Mode};
 use crate::pac::usbpd::vals;
 use crate::{interrupt, pac, println, Peri, PeripheralType, RccPeripheral};
 
@@ -75,26 +76,132 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
     }
 }
 
-pub struct UsbPdPhy<'d, T: Instance> {
-    _marker: PhantomData<&'d mut T>,
+pub struct UsbPdPhy<'d, T: Instance, M: Mode> {
+    _marker: PhantomData<(&'d mut T, M)>,
     cc1: vals::CcSel,
     cc2: vals::CcSel,
 }
 
-impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
-    /// Create a new SPI driver.
-    pub fn new(_peri: Peri<'d, T>, cc1: Peri<'d, impl CcPin<T>>, cc2: Peri<'d, impl CcPin<T>>) -> Result<Self, Error> {
+impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Async> {
+    pub fn new_async(
+        peri: Peri<'d, T>,
+        cc1: Peri<'d, impl CcPin<T>>,
+        cc2: Peri<'d, impl CcPin<T>>,
+    ) -> Result<UsbPdPhy<'d, T, Async>, Error> {
+        unsafe {
+            use crate::interrupt::typelevel::Interrupt;
+            T::Interrupt::enable();
+        };
+
+        Self::new_inner(peri, cc1, cc2)
+    }
+
+    fn enable_rx_interrupt(&mut self) {
+        T::REGS.config().modify(|w| {
+            w.set_ie_rx_act(true); // Receive completion interrupt enable
+            w.set_ie_rx_reset(true); // Receive reset interrupt enable
+            w.set_ie_tx_end(false); // End-of-transmit interrupt disable
+        });
+    }
+
+    fn enable_tx_interrupt(&mut self) {
+        T::REGS.config().modify(|w| {
+            w.set_ie_rx_act(false); // Receive completion interrupt disable
+            w.set_ie_rx_reset(false); // Receive reset interrupt disable
+            w.set_ie_tx_end(true); // End-of-transmit interrupt enable
+        });
+    }
+
+    /// Receives a PD message into the provided buffer.
+    ///
+    /// Returns the number of received bytes or an error.
+    pub async fn receive(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        self.enable_rx_interrupt();
+        self.prepare_receive(buf);
+
+        poll_fn(|cx| {
+            T::state().waker.register(cx.waker());
+
+            if !T::REGS.config().read().ie_rx_reset() {
+                return Poll::Ready(());
+            }
+
+            if !T::REGS.config().read().ie_rx_act() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+        self.post_receive()
+    }
+
+    /// Transmit a hard reset.
+    pub async fn transmit_hardreset(&mut self) {
+        const TX_SEL_HARD_RESET: u8 = 0b10_10_10_01;
+
+        self.enable_tx_interrupt();
+        self.transmit_inner(TX_SEL_HARD_RESET, &[]);
+        self.wait_for_tx_complete().await;
+
+        T::port_cc_reg(vals::CcSel::CC1).modify(|w| w.set_cc_lve(false));
+        T::port_cc_reg(vals::CcSel::CC2).modify(|w| w.set_cc_lve(false));
+    }
+
+    async fn wait_for_tx_complete(&mut self) {
+        poll_fn(|cx| {
+            T::state().waker.register(cx.waker());
+            let config = T::REGS.config().read();
+            if !config.ie_tx_end() {
+                return Poll::Ready(());
+            }
+            Poll::Pending
+        })
+        .await;
+    }
+}
+
+impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Blocking> {
+    pub fn new_blocking(
+        peri: Peri<'d, T>,
+        cc1: Peri<'d, impl CcPin<T>>,
+        cc2: Peri<'d, impl CcPin<T>>,
+    ) -> Result<UsbPdPhy<'d, T, Blocking>, Error> {
+        Self::new_inner(peri, cc1, cc2)
+    }
+
+    pub fn receive(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        unsafe {
+            qingke::pfic::disable_interrupt(interrupt::USBPD.number() as _);
+        }
+        self.prepare_receive(buf);
+
+        println!("begin blocking recv");
+
+        while !T::REGS.status().read().if_rx_act() {
+            // println!("wait");
+        }
+
+        unsafe {
+            qingke::pfic::enable_interrupt(interrupt::USBPD.number() as _);
+        }
+        self.post_receive()
+    }
+}
+
+impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
+    /// Create a new USB-PD driver.
+    fn new_inner(
+        _peri: Peri<'d, T>,
+        cc1: Peri<'d, impl CcPin<T>>,
+        cc2: Peri<'d, impl CcPin<T>>,
+    ) -> Result<Self, Error> {
         assert!(cc1.port_sel() != cc2.port_sel(), "CC1 and CC2 should be different");
 
         #[allow(unused)]
         let afio = crate::pac::AFIO;
 
         T::enable_and_reset();
-
-        unsafe {
-            use crate::interrupt::typelevel::Interrupt;
-            T::Interrupt::enable();
-        };
 
         cc1.set_as_input(Pull::None);
         cc2.set_as_input(Pull::None);
@@ -199,22 +306,6 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
         }
     }
 
-    fn enable_rx_interrupt(&mut self) {
-        T::REGS.config().modify(|w| {
-            w.set_ie_rx_act(true); // Receive completion interrupt enable
-            w.set_ie_rx_reset(true); // Receive reset interrupt enable
-            w.set_ie_tx_end(false); // End-of-transmit interrupt disable
-        });
-    }
-
-    fn enable_tx_interrupt(&mut self) {
-        T::REGS.config().modify(|w| {
-            w.set_ie_rx_act(false); // Receive completion interrupt disable
-            w.set_ie_rx_reset(false); // Receive reset interrupt disable
-            w.set_ie_tx_end(true); // End-of-transmit interrupt enable
-        });
-    }
-
     /// Prepares the PHY for receiving a PD message into a buffer.
     fn prepare_receive(&mut self, buf: &mut [u8]) {
         // set rx mode
@@ -243,49 +334,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
         }
     }
 
-    /// Receives a PD message into the provided buffer.
-    ///
-    /// Returns the number of received bytes or an error.
-    pub async fn receive(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
-        self.enable_rx_interrupt();
-        self.prepare_receive(buf);
-
-        poll_fn(|cx| {
-            T::state().waker.register(cx.waker());
-
-            if !T::REGS.config().read().ie_rx_reset() {
-                return Poll::Ready(());
-            }
-
-            if !T::REGS.config().read().ie_rx_act() {
-                Poll::Ready(())
-            } else {
-                Poll::Pending
-            }
-        })
-        .await;
-        self.post_receive()
-    }
-
-    pub fn blocking_receive(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
-        unsafe {
-            qingke::pfic::disable_interrupt(interrupt::USBPD.number() as _);
-        }
-        self.prepare_receive(buf);
-
-        println!("begin blocking recv");
-
-        while !T::REGS.status().read().if_rx_act() {
-            // println!("wait");
-        }
-
-        unsafe {
-            qingke::pfic::enable_interrupt(interrupt::USBPD.number() as _);
-        }
-        self.post_receive()
-    }
-
-    fn transmit(&mut self, sop: u8, buf: &[u8]) -> Result<(), Error> {
+    fn transmit_inner(&mut self, sop: u8, buf: &[u8]) {
         T::port_cc_reg(T::REGS.config().read().cc_sel()).modify(|w| w.set_cc_lve(true));
 
         T::REGS
@@ -313,35 +362,6 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
         });
 
         T::REGS.control().modify(|w| w.set_bmc_start(true));
-
-        Ok(())
-    }
-
-    /// Transmit a hard reset.
-    pub async fn transmit_hardreset(&mut self) {
-        const TX_SEL_HARD_RESET: u8 = 0b10_10_10_01;
-
-        self.enable_tx_interrupt();
-        self.transmit(TX_SEL_HARD_RESET, &[]).unwrap();
-        self.wait_for_tx_complete().await;
-
-        T::port_cc_reg(vals::CcSel::CC1).modify(|w| w.set_cc_lve(false));
-        T::port_cc_reg(vals::CcSel::CC2).modify(|w| w.set_cc_lve(false));
-
-        //        T::REGS.port_cc1().write(|w| w.set_cc_ce(vals::PortCcCe::V0_66));
-        //      T::REGS.port_cc2().write(|w| w.set_cc_ce(vals::PortCcCe::V0_66));
-    }
-
-    async fn wait_for_tx_complete(&mut self) {
-        poll_fn(|cx| {
-            T::state().waker.register(cx.waker());
-            let config = T::REGS.config().read();
-            if !config.ie_tx_end() {
-                return Poll::Ready(());
-            }
-            Poll::Pending
-        })
-        .await;
     }
 }
 

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -337,29 +337,18 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
     pub async fn transmit_hardreset(&mut self) {
         const TX_SEL_HARD_RESET: u8 = 0b10_10_10_01;
 
-        // self.enable_tx_interrupt();
-        // self.transmit(TX_SEL_HARD_RESET, &[])?;
-        // send_phy_empty_playload
-
-        T::port_cc_reg(T::REGS.config().read().cc_sel()).modify(|w| w.set_cc_lve(true));
-
-        T::REGS
-            .bmc_clk_cnt()
-            .write(|w| w.set_bmc_clk_cnt(calc_bmc_clk_for_tx()));
-
-        T::REGS.dma().write_value(0);
-        T::REGS.tx_sel().write(|w| w.0 = TX_SEL_HARD_RESET);
-        T::REGS.bmc_tx_sz().write(|w| w.set_bmc_tx_sz(0));
-
-        T::REGS.control().modify(|w| w.set_pd_tx_en(true)); // TX
-
-        T::REGS.status().write(|w| w.0 = 0b11111100);
-
         self.enable_tx_interrupt();
+        self.transmit(TX_SEL_HARD_RESET, &[]).unwrap();
+        self.wait_for_tx_complete().await;
 
-        // Start transmission
-        T::REGS.control().modify(|w| w.set_bmc_start(true));
+        T::port_cc_reg(vals::CcSel::CC1).modify(|w| w.set_cc_lve(false));
+        T::port_cc_reg(vals::CcSel::CC2).modify(|w| w.set_cc_lve(false));
 
+        //        T::REGS.port_cc1().write(|w| w.set_cc_ce(vals::PortCcCe::V0_66));
+        //      T::REGS.port_cc2().write(|w| w.set_cc_ce(vals::PortCcCe::V0_66));
+    }
+
+    async fn wait_for_tx_complete(&mut self) {
         poll_fn(|cx| {
             T::state().waker.register(cx.waker());
             let config = T::REGS.config().read();
@@ -369,14 +358,6 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
             Poll::Pending
         })
         .await;
-
-        T::port_cc_reg(vals::CcSel::CC1).modify(|w| w.set_cc_lve(false));
-        T::port_cc_reg(vals::CcSel::CC2).modify(|w| w.set_cc_lve(false));
-
-        //        T::REGS.port_cc1().write(|w| w.set_cc_ce(vals::PortCcCe::V0_66));
-        //      T::REGS.port_cc2().write(|w| w.set_cc_ce(vals::PortCcCe::V0_66));
-
-        // Ok(())
     }
 }
 

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -225,6 +225,24 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Blocking> {
         }
         self.post_receive(buf)
     }
+
+    pub fn transmit(&mut self, buf: &[u8]) {
+        unsafe {
+            qingke::pfic::disable_interrupt(interrupt::USBPD.number() as _);
+        }
+        self.transmit_inner(Sop::Sop, buf);
+
+        while !T::REGS.status().read().if_tx_end() {
+            // println!("wait");
+        }
+
+        T::port_cc_reg(vals::CcSel::CC1).modify(|w| w.set_cc_lve(false));
+        T::port_cc_reg(vals::CcSel::CC2).modify(|w| w.set_cc_lve(false));
+
+        unsafe {
+            qingke::pfic::enable_interrupt(interrupt::USBPD.number() as _);
+        }
+    }
 }
 
 impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -386,6 +386,7 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
             return Err(Error::HardReset);
         }
         let byte_count = T::REGS.bmc_byte_cnt().read().bmc_byte_cnt() as usize;
+        let byte_count = byte_count.saturating_sub(4); // Strip the 4-byte CRC
         buf[..byte_count].copy_from_slice(&self.buffer.to_slice()[..byte_count]);
         match T::REGS.status().read().bmc_aux() {
             vals::BmcAux::SOP0 => Ok((Sop::Sop, byte_count)),

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -118,7 +118,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Async> {
         cc1: Peri<'d, impl CcPin<T>>,
         cc2: Peri<'d, impl CcPin<T>>,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
-    ) -> Result<UsbPdPhy<'d, T, Async>, Error> {
+    ) -> UsbPdPhy<'d, T, Async> {
         unsafe {
             use crate::interrupt::typelevel::Interrupt;
             T::Interrupt::enable();
@@ -204,7 +204,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Blocking> {
         peri: Peri<'d, T>,
         cc1: Peri<'d, impl CcPin<T>>,
         cc2: Peri<'d, impl CcPin<T>>,
-    ) -> Result<UsbPdPhy<'d, T, Blocking>, Error> {
+    ) -> UsbPdPhy<'d, T, Blocking> {
         Self::new_inner(peri, cc1, cc2)
     }
 
@@ -256,11 +256,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Blocking> {
 
 impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
     /// Create a new USB-PD driver.
-    fn new_inner(
-        _peri: Peri<'d, T>,
-        cc1: Peri<'d, impl CcPin<T>>,
-        cc2: Peri<'d, impl CcPin<T>>,
-    ) -> Result<Self, Error> {
+    fn new_inner(_peri: Peri<'d, T>, cc1: Peri<'d, impl CcPin<T>>, cc2: Peri<'d, impl CcPin<T>>) -> Self {
         assert!(cc1.port_sel() != cc2.port_sel(), "CC1 and CC2 should be different");
 
         #[allow(unused)]
@@ -309,9 +305,8 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
             cc2: cc2.port_sel(),
             buffer: UsbPdMsg::new(),
         };
-        this.detect_cc()?;
 
-        Ok(this)
+        this
     }
 
     pub fn reset(&mut self) -> Result<(), Error> {
@@ -342,7 +337,7 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
         Ok(())
     }
 
-    fn detect_cc(&mut self) -> Result<(), Error> {
+    pub fn detect_cc(&self) -> Result<(), Error> {
         // CH32X035 has no internal CC pull down support
         // The detection voltage is 0.22V, sufficient to detect the default power(500mA/900mA)
 

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -349,7 +349,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
 
         T::REGS.dma().write_value(0);
         T::REGS.tx_sel().write(|w| w.0 = TX_SEL_HARD_RESET);
-        T::REGS.bmc_byte_cnt().write(|w| w.set_bmc_byte_cnt(0));
+        T::REGS.bmc_tx_sz().write(|w| w.set_bmc_tx_sz(0));
 
         T::REGS.control().modify(|w| w.set_pd_tx_en(true)); // TX
 

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -123,7 +123,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Async> {
     /// Receives a PD message into the provided buffer.
     ///
     /// Returns the number of received bytes or an error.
-    pub async fn receive(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+    pub async fn receive(&mut self, buf: &mut [u8]) -> Result<(Sop, usize), Error> {
         self.enable_rx_interrupt();
         self.prepare_receive(buf);
 
@@ -176,7 +176,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Blocking> {
         Self::new_inner(peri, cc1, cc2)
     }
 
-    pub fn receive(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+    pub fn receive(&mut self, buf: &mut [u8]) -> Result<(Sop, usize), Error> {
         unsafe {
             qingke::pfic::disable_interrupt(interrupt::USBPD.number() as _);
         }
@@ -328,14 +328,16 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
         T::REGS.control().modify(|w| w.set_bmc_start(true));
     }
 
-    /// Decodes the received PD message and returns its length or an error.
-    fn post_receive(&mut self) -> Result<usize, Error> {
+    /// Decodes the received PD message and returns a tuple (Sop, length) or an error.
+    fn post_receive(&self) -> Result<(Sop, usize), Error> {
         if T::REGS.status().read().if_rx_reset() {
             return Err(Error::HardReset);
         }
+        let byte_count = T::REGS.bmc_byte_cnt().read().bmc_byte_cnt() as usize;
         match T::REGS.status().read().bmc_aux() {
-            vals::BmcAux::SOP0 => Ok(T::REGS.bmc_byte_cnt().read().bmc_byte_cnt() as usize),
-            vals::BmcAux::SOP1 => Err(Error::NotSupported),
+            vals::BmcAux::SOP0 => Ok((Sop::Sop, byte_count)),
+            vals::BmcAux::SOP1 => Ok((Sop::SopPrime, byte_count)),
+            vals::BmcAux::SOP2 => Ok((Sop::SopDoublePrime, byte_count)),
             _ => Err(Error::Rejected),
         }
     }

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -33,6 +33,14 @@ pub enum Error {
     MaxRetry,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum Sop {
+    Sop = 0b00_00_00_00,
+    SopPrime = 0b00_00_01_01,
+    SopDoublePrime = 0b00_01_00_01,
+    HardReset = 0b10_10_10_01,
+}
+
 /// Interrupt handler.
 pub struct InterruptHandler<T: Instance> {
     _phantom: PhantomData<T>,
@@ -138,10 +146,8 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Async> {
 
     /// Transmit a hard reset.
     pub async fn transmit_hardreset(&mut self) {
-        const TX_SEL_HARD_RESET: u8 = 0b10_10_10_01;
-
         self.enable_tx_interrupt();
-        self.transmit_inner(TX_SEL_HARD_RESET, &[]);
+        self.transmit_inner(Sop::HardReset, &[]);
         self.wait_for_tx_complete().await;
 
         T::port_cc_reg(vals::CcSel::CC1).modify(|w| w.set_cc_lve(false));
@@ -334,7 +340,7 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
         }
     }
 
-    fn transmit_inner(&mut self, sop: u8, buf: &[u8]) {
+    fn transmit_inner(&mut self, sop: Sop, buf: &[u8]) {
         T::port_cc_reg(T::REGS.config().read().cc_sel()).modify(|w| w.set_cc_lve(true));
 
         T::REGS
@@ -347,7 +353,7 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
             T::REGS.dma().write_value(buf.as_ptr() as u16);
         }
 
-        T::REGS.tx_sel().write(|w| w.0 = sop);
+        T::REGS.tx_sel().write(|w| w.0 = sop as u8);
 
         T::REGS.bmc_tx_sz().write(|w| w.set_bmc_tx_sz(buf.len() as _));
         T::REGS.control().modify(|w| w.set_pd_tx_en(true)); // TX

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -84,10 +84,33 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
     }
 }
 
+#[repr(align(4))]
+struct UsbPdMsg {
+    pub data: [u8; 30],
+}
+impl UsbPdMsg {
+    fn new() -> Self {
+        Self { data: [0u8; 30] }
+    }
+
+    fn to_slice(&self) -> &[u8] {
+        &self.data
+    }
+
+    fn address(&self) -> u16 {
+        self.data.as_ptr() as u16
+    }
+
+    fn mut_address(&mut self) -> u16 {
+        self.data.as_mut_ptr() as u16
+    }
+}
+
 pub struct UsbPdPhy<'d, T: Instance, M: Mode> {
     _marker: PhantomData<(&'d mut T, M)>,
     cc1: vals::CcSel,
     cc2: vals::CcSel,
+    buffer: UsbPdMsg,
 }
 
 impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Async> {
@@ -125,7 +148,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Async> {
     /// Returns the number of received bytes or an error.
     pub async fn receive(&mut self, buf: &mut [u8]) -> Result<(Sop, usize), Error> {
         self.enable_rx_interrupt();
-        self.prepare_receive(buf);
+        self.prepare_receive();
 
         poll_fn(|cx| {
             T::state().waker.register(cx.waker());
@@ -141,7 +164,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Async> {
             }
         })
         .await;
-        self.post_receive()
+        self.post_receive(buf)
     }
 
     /// Transmit a hard reset.
@@ -180,7 +203,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Blocking> {
         unsafe {
             qingke::pfic::disable_interrupt(interrupt::USBPD.number() as _);
         }
-        self.prepare_receive(buf);
+        self.prepare_receive();
 
         println!("begin blocking recv");
 
@@ -191,7 +214,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Blocking> {
         unsafe {
             qingke::pfic::enable_interrupt(interrupt::USBPD.number() as _);
         }
-        self.post_receive()
+        self.post_receive(buf)
     }
 }
 
@@ -248,6 +271,7 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
             _marker: PhantomData,
             cc1: cc1.port_sel(),
             cc2: cc2.port_sel(),
+            buffer: UsbPdMsg::new(),
         };
         this.detect_cc()?;
 
@@ -313,12 +337,12 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
     }
 
     /// Prepares the PHY for receiving a PD message into a buffer.
-    fn prepare_receive(&mut self, buf: &mut [u8]) {
+    fn prepare_receive(&mut self) {
         // set rx mode
         T::REGS.config().modify(|w| w.set_pd_all_clr(true));
         T::REGS.config().modify(|w| w.set_pd_all_clr(false));
 
-        T::REGS.dma().write_value((buf.as_mut_ptr() as u32 & 0xFFFF) as u16);
+        T::REGS.dma().write_value(self.buffer.mut_address());
 
         T::REGS.control().modify(|w| w.set_pd_tx_en(false)); // RX
         T::REGS
@@ -329,11 +353,12 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
     }
 
     /// Decodes the received PD message and returns a tuple (Sop, length) or an error.
-    fn post_receive(&self) -> Result<(Sop, usize), Error> {
+    fn post_receive(&self, buf: &mut [u8]) -> Result<(Sop, usize), Error> {
         if T::REGS.status().read().if_rx_reset() {
             return Err(Error::HardReset);
         }
         let byte_count = T::REGS.bmc_byte_cnt().read().bmc_byte_cnt() as usize;
+        buf[..byte_count].copy_from_slice(&self.buffer.to_slice()[..byte_count]);
         match T::REGS.status().read().bmc_aux() {
             vals::BmcAux::SOP0 => Ok((Sop::Sop, byte_count)),
             vals::BmcAux::SOP1 => Ok((Sop::SopPrime, byte_count)),
@@ -352,7 +377,9 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
         if buf.is_empty() {
             T::REGS.dma().write_value(0);
         } else {
-            T::REGS.dma().write_value(buf.as_ptr() as u16);
+            // We use our own buffer to ensure it is 4-byte aligned, as required by the hardware.
+            self.buffer.data[..buf.len()].copy_from_slice(buf);
+            T::REGS.dma().write_value(self.buffer.address());
         }
 
         T::REGS.tx_sel().write(|w| w.0 = sop as u8);

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -167,6 +167,15 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Async> {
         self.post_receive(buf)
     }
 
+    pub async fn transmit(&mut self, buf: &[u8]) {
+        self.enable_tx_interrupt();
+        self.transmit_inner(Sop::Sop, buf);
+        self.wait_for_tx_complete().await;
+
+        T::port_cc_reg(vals::CcSel::CC1).modify(|w| w.set_cc_lve(false));
+        T::port_cc_reg(vals::CcSel::CC2).modify(|w| w.set_cc_lve(false));
+    }
+
     /// Transmit a hard reset.
     pub async fn transmit_hardreset(&mut self) {
         self.enable_tx_interrupt();

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -91,6 +91,11 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
 
         T::enable_and_reset();
 
+        unsafe {
+            use crate::interrupt::typelevel::Interrupt;
+            T::Interrupt::enable();
+        };
+
         cc1.set_as_input(Pull::None);
         cc2.set_as_input(Pull::None);
 
@@ -348,9 +353,10 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
 
         T::REGS.status().write(|w| w.0 = 0b11111100);
 
-        T::REGS.control().modify(|w| w.set_bmc_start(true));
+        self.enable_tx_interrupt();
 
-        /*
+        // Start transmission
+        T::REGS.control().modify(|w| w.set_bmc_start(true));
 
         poll_fn(|cx| {
             T::state().waker.register(cx.waker());
@@ -362,14 +368,13 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
         })
         .await;
 
-        // T::REGS.port_cc1().modify(|w| w.set_cc_lve(false));
-        // T::REGS.port_cc2().modify(|w| w.set_cc_lve(false));
+        T::port_cc_reg(vals::CcSel::CC1).modify(|w| w.set_cc_lve(false));
+        T::port_cc_reg(vals::CcSel::CC2).modify(|w| w.set_cc_lve(false));
 
         //        T::REGS.port_cc1().write(|w| w.set_cc_ce(vals::PortCcCe::V0_66));
         //      T::REGS.port_cc2().write(|w| w.set_cc_ce(vals::PortCcCe::V0_66));
 
-        Ok(())
-        */
+        // Ok(())
     }
 }
 

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -118,6 +118,7 @@ impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T, Async> {
         peri: Peri<'d, T>,
         cc1: Peri<'d, impl CcPin<T>>,
         cc2: Peri<'d, impl CcPin<T>>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
     ) -> Result<UsbPdPhy<'d, T, Async>, Error> {
         unsafe {
             use crate::interrupt::typelevel::Interrupt;

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -83,11 +83,7 @@ pub struct UsbPdPhy<'d, T: Instance> {
 
 impl<'d, T: Instance + PeripheralType> UsbPdPhy<'d, T> {
     /// Create a new SPI driver.
-    pub fn new(
-        _peri: Peri<'d, T>,
-        cc1: Peri<'d, impl CcPin<T>>,
-        cc2: Peri<'d, impl CcPin<T>>,
-    ) -> Result<Self, Error> {
+    pub fn new(_peri: Peri<'d, T>, cc1: Peri<'d, impl CcPin<T>>, cc2: Peri<'d, impl CcPin<T>>) -> Result<Self, Error> {
         assert!(cc1.port_sel() != cc2.port_sel(), "CC1 and CC2 should be different");
 
         #[allow(unused)]

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -329,7 +329,7 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
         }
         match T::REGS.status().read().bmc_aux() {
             vals::BmcAux::SOP0 => Ok(T::REGS.bmc_byte_cnt().read().bmc_byte_cnt() as usize),
-            vals::BmcAux::SOP1 => Err(Error::HardReset),
+            vals::BmcAux::SOP1 => Err(Error::NotSupported),
             _ => Err(Error::Rejected),
         }
     }


### PR DESCRIPTION
This has been tested on CH32L103 and CH32X035 and can communicate with USB-PD adapters.

- **chore(usbpd): Reformat code**
- **chore(usbpd): Add comments to make code more readable**
- **fix(usbpd): Implement async wait in transmit_hardreset**
- **fix(usbpd): Don't enable rx interrupt in tx mode**
- **fix(usbpd): Return the number of bytes received in blocking_receive()**
- **fix(usbpd): Set the correct register for the payload length**
- **feat(usbpd): Reuse the transmit function in transmit_hardreset**
- **chore(usbpd): Deduplicate rx logic into reusable functions**
- **feat(usbpd): Split implementation into async and blocking variant**
- **fix(usbpd): SOP1 is not HardReset**
- **feat(usbpd): Use an enum for start of packet sequence**
- **feat(usbpd): Return the SOP when receiving a packet**
- **feat(usbpd): Use our own buffer to ensure it is 4-byte aligned, as required by the hardware**
- **feat(usbpd): Add async transmit function**
- **feat(usbpd): Add blocking transmit function**
- **fix(usbpd): Typo**
- **fix(usbpd): Disable print in interrupt**
- **feat(usbpd): Take the irq as parameter to make sure the interrupt is setup correctly**
