### PR TITLE
ble: CH32V208 BLE PHY init + RF calibration (Phase 1 + Phase 2 skeleton)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ trash/
 .vscode/
 
 .DS_Store
+examples/dev

--- a/examples/ch32v208/src/bin/ble_adv.rs
+++ b/examples/ch32v208/src/bin/ble_adv.rs
@@ -39,7 +39,25 @@ fn main() -> ! {
     let adv_data = &adv_data[..pos];
 
     unsafe {
+        // ── RCC / clock diagnostic (before BLE init) ─────────────────────────
+        // RCC base = 0x40021000
+        //   CTLR (+0x00): bit1=HSIRDY, bit16=HSEON, bit17=HSERDY, bit24=PLLON, bit25=PLLRDY
+        //   CFGR0(+0x04): bits[3:2]=SWS (00=HSI, 01=HSE, 10=PLL)
+        let rcc_ctlr  = core::ptr::read_volatile(0x4002_1000 as *const u32);
+        let rcc_cfgr0 = core::ptr::read_volatile(0x4002_1004 as *const u32);
+        let hsirdy  = (rcc_ctlr >> 1)  & 1;
+        let hserdy  = (rcc_ctlr >> 17) & 1;
+        let pllrdy  = (rcc_ctlr >> 25) & 1;
+        let sws     = (rcc_cfgr0 >> 2) & 0x3; // active clock source
+        hal::println!("RCC pre-init: ctlr=0x{rcc_ctlr:08x} cfgr0=0x{rcc_cfgr0:08x}");
+        hal::println!("  hsirdy={hsirdy} hserdy={hserdy} pllrdy={pllrdy} sws={sws} (2=PLL expected)");
+
         hal::ble::ble_phy_init();
+
+        // ── BLE register diagnostic (after init) ─────────────────────────────
+        let rcc_ctlr2 = core::ptr::read_volatile(0x4002_1000 as *const u32);
+        let hserdy2   = (rcc_ctlr2 >> 17) & 1;
+        hal::println!("RCC post-init: hserdy={hserdy2} (must be 1 for RF)");
 
         // Dump LLE+0x2C after init — ch_2c should be 37/38/39 after first adv_event.
         let (lle_2c, _bb04, ctrl) = diag_read();

--- a/examples/ch32v208/src/bin/ble_adv.rs
+++ b/examples/ch32v208/src/bin/ble_adv.rs
@@ -16,7 +16,7 @@
 
 use {ch32_hal as hal, panic_halt as _};
 
-use hal::ble::adv::{ADV_DATA_MAX, ad_complete_name, ad_flags, adv_event, adv_event_verbose, diag_read};
+use hal::ble::adv::{ADV_DATA_MAX, ad_complete_name, ad_flags, adv_event, diag_read};
 
 // 6-byte device address LE order. Random static requires bits[47:46] = 11
 // (= last byte bits[7:6] = 11, BLE Core Spec Vol 6 Part B §1.3.2.1).
@@ -40,34 +40,26 @@ fn main() -> ! {
 
     unsafe {
         hal::ble::ble_phy_init();
-        hal::println!("PHY init done, advertising...");
-        hal::println!("[DIAG] state_machine + IRQ diagnostic mode");
+
+        // Dump LLE+0x2C after init — ch_2c should be 37/38/39 after first adv_event.
+        let (lle_2c, _bb04, ctrl) = diag_read();
+        hal::println!("PHY init: lle_2c=0x{lle_2c:08x} ch_2c={} wh={} ctrl=0x{ctrl:08x}",
+            (lle_2c >> 25) & 0x3F, (ctrl >> 6) & 1);
 
         let mut total = 0u32;
         let mut ok_total = 0u32;
 
         loop {
-            let ok;
-            if total < 5 {
-                // Verbose diagnostic for first 5 events.
-                let (n, stats) = adv_event_verbose(&ADDR, true, adv_data);
-                ok = n;
-                for (i, (init, fin, irq_final, state_pre, state_post, irq_post)) in stats.iter().enumerate() {
-                    let ch = [37u8, 38, 39][i];
-                    // state_pre/post: 108=Sleep; non-108 means HW accepted GO.
-                    // irq_post bits[15:0]: non-zero means TX-completion IRQ fired right after GO.
-                    hal::println!("[DIAG#{total}:ch{ch}] bb64={init}->{fin} irq_final=0x{irq_final:08x} | state={state_pre}->{state_post} irq_post=0x{irq_post:08x}");
-                }
-                let (lle_2c, bb04, ctrl) = diag_read();
-                hal::println!("[DIAG#{total}] lle_2c=0x{lle_2c:08x} bb04=0x{bb04:02x} ctrl=0x{ctrl:08x} ch_2c={} wh={}",
-                    (lle_2c >> 25) & 0x3F, (ctrl >> 6) & 1);
-            } else {
-                ok = adv_event(&ADDR, true, adv_data);
-            }
+            let ok = adv_event(&ADDR, true, adv_data);
             ok_total += ok as u32;
             total += 1;
 
-            if total <= 5 || total % 500 == 0 {
+            // Log ch_2c for first 5 events to confirm LLE+0x2C bits[30:25] are updated.
+            if total <= 5 {
+                let (lle_2c, _bb04, ctrl) = diag_read();
+                hal::println!("adv #{total}: {ok}/3 ok | lle_2c=0x{lle_2c:08x} ch_2c={} wh={}",
+                    (lle_2c >> 25) & 0x3F, (ctrl >> 6) & 1);
+            } else if total % 500 == 0 {
                 hal::println!("adv #{}: {}/3 channels ok (cumulative {}/{})",
                     total, ok, ok_total, total * 3);
             }

--- a/examples/ch32v208/src/bin/ble_adv.rs
+++ b/examples/ch32v208/src/bin/ble_adv.rs
@@ -18,9 +18,9 @@ use {ch32_hal as hal, panic_halt as _};
 
 use hal::ble::adv::{ADV_DATA_MAX, ad_complete_name, ad_flags, adv_event};
 
-// 6-byte device address (random static — bit[1] of last byte must be 1 for random static).
-// Using a fixed address for easy identification during testing.
-const ADDR: [u8; 6] = [0x12, 0x34, 0x56, 0x78, 0x9A, 0xC2]; // C2 = 0b11000010: bits[7:6]=11 (random static)
+// 6-byte device address LE order. Random static requires bits[47:46] = 11
+// (= last byte bits[7:6] = 11, BLE Core Spec Vol 6 Part B §1.3.2.1).
+const ADDR: [u8; 6] = [0x12, 0x34, 0x56, 0x78, 0x9A, 0xC2]; // 0xC2 = 0b11000010 → bits[7:6]=11 ✓
 
 #[qingke_rt::entry]
 fn main() -> ! {

--- a/examples/ch32v208/src/bin/ble_adv.rs
+++ b/examples/ch32v208/src/bin/ble_adv.rs
@@ -16,7 +16,7 @@
 
 use {ch32_hal as hal, panic_halt as _};
 
-use hal::ble::adv::{ADV_DATA_MAX, ad_complete_name, ad_flags, adv_event};
+use hal::ble::adv::{ADV_DATA_MAX, ad_complete_name, ad_flags, adv_event, adv_event_verbose, diag_read};
 
 // 6-byte device address LE order. Random static requires bits[47:46] = 11
 // (= last byte bits[7:6] = 11, BLE Core Spec Vol 6 Part B §1.3.2.1).
@@ -41,12 +41,29 @@ fn main() -> ! {
     unsafe {
         hal::ble::ble_phy_init();
         hal::println!("PHY init done, advertising...");
+        hal::println!("[DIAG] state_machine + IRQ diagnostic mode");
 
         let mut total = 0u32;
         let mut ok_total = 0u32;
 
         loop {
-            let ok = adv_event(&ADDR, true, adv_data);
+            let ok;
+            if total < 5 {
+                // Verbose diagnostic for first 5 events.
+                let (n, stats) = adv_event_verbose(&ADDR, true, adv_data);
+                ok = n;
+                for (i, (init, fin, irq_final, state_pre, state_post, irq_post)) in stats.iter().enumerate() {
+                    let ch = [37u8, 38, 39][i];
+                    // state_pre/post: 108=Sleep; non-108 means HW accepted GO.
+                    // irq_post bits[15:0]: non-zero means TX-completion IRQ fired right after GO.
+                    hal::println!("[DIAG#{total}:ch{ch}] bb64={init}->{fin} irq_final=0x{irq_final:08x} | state={state_pre}->{state_post} irq_post=0x{irq_post:08x}");
+                }
+                let (lle_2c, bb04, ctrl) = diag_read();
+                hal::println!("[DIAG#{total}] lle_2c=0x{lle_2c:08x} bb04=0x{bb04:02x} ctrl=0x{ctrl:08x} ch_2c={} wh={}",
+                    (lle_2c >> 25) & 0x3F, (ctrl >> 6) & 1);
+            } else {
+                ok = adv_event(&ADDR, true, adv_data);
+            }
             ok_total += ok as u32;
             total += 1;
 
@@ -55,8 +72,9 @@ fn main() -> ! {
                     total, ok, ok_total, total * 3);
             }
 
-            // ~31 ms gap between advertising events (spec minimum is 20 ms).
-            qingke::riscv::asm::delay(20_000 * 50);
+            // ~247 ms gap — distinctive timing signature for SDR ON/OFF differential.
+            // (At 144 MHz, ~4 cycles/iter: 8_900_000 * 4 / 144_000_000 ≈ 247 ms)
+            qingke::riscv::asm::delay(20_000 * 445);
         }
     }
 }

--- a/examples/ch32v208/src/bin/ble_adv.rs
+++ b/examples/ch32v208/src/bin/ble_adv.rs
@@ -1,0 +1,62 @@
+//! BLE ADV_NONCONN_IND advertising example for CH32V208.
+//!
+//! Broadcasts a non-connectable undirected advertising packet on all three
+//! BLE advertising channels (ch37=2402 / ch38=2426 / ch39=2480 MHz) in a loop.
+//! Verifiable with nRF Connect (phone), Wireshark + BLE sniffer, or SDR.
+//!
+//! # How to verify
+//!
+//! 1. Flash: `cargo run --bin ble_adv --release`
+//! 2. Open nRF Connect on a phone → Scanner → look for "ch32-hal"
+//! 3. Optional: HackRF/RTL-SDR at 2402/2426/2480 MHz, observe GFSK bursts
+//! 4. Optional: Wireshark + nRF Sniffer → confirm ADV_NONCONN_IND PDU + correct AdvA
+
+#![no_std]
+#![no_main]
+
+use {ch32_hal as hal, panic_halt as _};
+
+use hal::ble::adv::{ADV_DATA_MAX, ad_complete_name, ad_flags, adv_event};
+
+// 6-byte device address (random static — bit[1] of last byte must be 1 for random static).
+// Using a fixed address for easy identification during testing.
+const ADDR: [u8; 6] = [0x12, 0x34, 0x56, 0x78, 0x9A, 0xC2]; // C2 = 0b11000010: bits[7:6]=11 (random static)
+
+#[qingke_rt::entry]
+fn main() -> ! {
+    hal::debug::SDIPrint::enable();
+    let _p = hal::init(Default::default());
+
+    hal::println!("BLE ADV — CH32V208");
+    hal::println!("addr: {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        ADDR[5], ADDR[4], ADDR[3], ADDR[2], ADDR[1], ADDR[0]);
+
+    // Build AdvData: Flags + Complete Local Name "ch32-hal"
+    let mut adv_data = [0u8; ADV_DATA_MAX];
+    let mut pos = 0;
+    pos += ad_flags(&mut adv_data[pos..], 0x06); // LE General Discoverable | BR/EDR Not Supported
+    pos += ad_complete_name(&mut adv_data[pos..], b"ch32-hal");
+    let adv_data = &adv_data[..pos];
+
+    unsafe {
+        hal::ble::ble_phy_init();
+        hal::println!("PHY init done, advertising...");
+
+        let mut total = 0u32;
+        let mut ok_total = 0u32;
+
+        loop {
+            let ok = adv_event(&ADDR, true, adv_data);
+            ok_total += ok as u32;
+            total += 1;
+
+            if total <= 5 || total % 500 == 0 {
+                hal::println!("adv #{}: {}/3 channels ok (cumulative {}/{})",
+                    total, ok, ok_total, total * 3);
+            }
+
+            // ~31 ms gap between advertising events (spec minimum is 20 ms).
+            qingke::riscv::asm::delay(20_000 * 50);
+        }
+    }
+}

--- a/examples/ch32v208/src/bin/ble_dtm_tx.rs
+++ b/examples/ch32v208/src/bin/ble_dtm_tx.rs
@@ -199,19 +199,15 @@ unsafe fn dtm_tx_burst(freq_khz: u32) {
     lle_write(0x2C, lle_cfg & !0x3);
 }
 
-/// Poll for TX done at gptrLLEReg+0x08 (0x40024208, W1C IRQ status).
-/// Hardware fires IRQ bits 29+25 (0x22000000) on TX completion — docs showed bit2
-/// but live observation shows upper bits. Write all-ones to clear (W1C).
+/// Poll for TX done — delegates to the shared `ble_tx_wait_done` primitive.
+///
+/// DTM packets are shorter than ADV (37-byte payload @ 1 Mbps ≈ 380µs + pre-delay).
+/// settle_loops = 60_000 ≈ 420µs at 144 MHz is conservative enough for any DTM PDU.
+///
+/// Note: BB+0x08 bits 29+25 are sticky (non-W1C) — the `bb_write(0x08, 0xFFFF_FFFF)`
+/// call in the old implementation was effectively a no-op for those bits.
 unsafe fn wait_tx_done() -> bool {
-    for _ in 0..10_000u32 {
-        if bb_read(0x08) != 0 {
-            bb_write(0x08, 0xFFFF_FFFF);
-            return true;
-        }
-        riscv::asm::nop();
-    }
-    bb_write(0x08, 0xFFFF_FFFF);
-    false
+    hal::ble::ble_tx_wait_done(10_000, 60_000)
 }
 
 // ── Entry point ──────────────────────────────────────────────────────────────

--- a/examples/ch32v208/src/bin/ble_dtm_tx.rs
+++ b/examples/ch32v208/src/bin/ble_dtm_tx.rs
@@ -1,0 +1,283 @@
+//! BLE Direct Test Mode (DTM) continuous TX example for CH32V208.
+//!
+//! Transmits a BLE test packet continuously on each advertising channel
+//! (2402 / 2426 / 2480 MHz) in round-robin rotation. Verifiable with any
+//! SDR (RTL-SDR, HackRF, etc.) or spectrum analyzer.
+//!
+//! # How to verify with SDR
+//!
+//! 1. Flash this binary: `cargo run --bin ble_dtm_tx --release`
+//! 2. Open SDR# / GNU Radio / gqrx, tune to 2402 MHz, ~2 MHz BW
+//! 3. You should see a GFSK burst every few ms; repeat for 2426 / 2480 MHz
+//!
+//! # Packet format on air (BLE 1M PHY)
+//!
+//! Preamble (1B, hw) | Access Address 0x71764129 (4B) |
+//! PDU: type(1B) + len(1B) + payload(37B) | CRC-24 (3B, hw)
+//!
+//! # Register block mapping (confirmed from dtm.elf BLE_IPCoreInit)
+//!
+//! WCH name        | Address     | Our accessors | Contents
+//! gptrBBReg       | 0x40024100  | lle_*         | CTRL/GO, TX mode, ACCESS_ADDR, CRC_INIT
+//! gptrLLEReg      | 0x40024200  | bb_*          | Timing, IRQ status, TX timer, TX buf ptr
+//! gptrAESReg      | 0x40024300  | (rfend init)  | RF analog config (init only)
+//! gptrRFENDReg    | 0x40025000  | rfend_*       | PA bias, PLL, channel lock
+//!
+//! Note: WCH's "BB" and "LLE" labels are counterintuitive — gptrBBReg holds the
+//! link-layer engine control registers while gptrLLEReg holds timing/scheduling.
+//!
+//! # TX sequence (from ll_hw_api_tx_direct_test + RF_DevSetChannel in libwchble V1.40)
+//!
+//! 1.  gptrBBReg+0x2C  bits[1:0]=01  TX mode arm
+//! 2.  gptrLLEReg+0x64 = 160         event timeout
+//! 3.  gptrRFENDReg+0x44             PLL int+frac dividers (RF_DevSetChannel)
+//!     gptrRFENDReg+0x2C bit1=1      channel lock set
+//! 4.  gptrBBReg+0x00  bits[8:7]=0, bit8=1  TX path select
+//! 5.  gptrRFENDReg+0x08 |= 0x330000  PA bias enable
+//! 6.  gptrLLEReg+0x50 = 90           TX pre-delay timer
+//! 7.  gptrRFENDReg+0x2C &= ~2        channel lock release
+//! 8.  gptrBBReg+0x00  bits[6:0] = channel index
+//! 9.  gptrBBReg+0x08  = ACCESS_ADDR (0x71764129)
+//! 10. gptrBBReg+0x04  = CRC_INIT (0x555555)
+//! 11. gptrLLEReg+0x70 = TX buffer ptr
+//! 12. gptrBBReg+0x00  &=~0x800, |=0x800  GO bit (clear then set for 0→1 edge)
+//! 13. gptrBBReg+0x2C  bits[1:0]=00   clear TX arm
+
+#![no_std]
+#![no_main]
+
+use core::ptr::{addr_of, read_volatile, write_volatile};
+use qingke::riscv;
+use {ch32_hal as hal, panic_halt as _};
+
+// ── Register base addresses ──────────────────────────────────────────────────
+// Confirmed from BLE_IPCoreInit in dtm.elf (WCH BLE SDK V1.40).
+
+/// gptrBBReg: link-layer CTRL/GO, TX mode, ACCESS_ADDR, CRC_INIT.
+const LLE_BASE: usize = 0x40024100;
+/// gptrLLEReg: timing params, IRQ status/mask, TX timer, TX buffer pointer.
+const BB_BASE: usize = 0x40024200;
+/// gptrRFENDReg: PA bias, PLL int/frac dividers, channel lock.
+const RFEND_BASE: usize = 0x40025000;
+
+// ── DTM constants (BLE Core Spec Vol 6 Part F) ───────────────────────────────
+
+const DTM_ACCESS_ADDR: u32 = 0x71764129;
+const DTM_CRC_INIT: u32 = 0x555555;
+
+// ── Register accessors ───────────────────────────────────────────────────────
+
+#[inline(always)]
+unsafe fn lle_read(off: usize) -> u32 {
+    read_volatile((LLE_BASE + off) as *const u32)
+}
+#[inline(always)]
+unsafe fn lle_write(off: usize, val: u32) {
+    write_volatile((LLE_BASE + off) as *mut u32, val);
+}
+
+#[inline(always)]
+unsafe fn bb_read(off: usize) -> u32 {
+    read_volatile((BB_BASE + off) as *const u32)
+}
+#[inline(always)]
+unsafe fn bb_write(off: usize, val: u32) {
+    write_volatile((BB_BASE + off) as *mut u32, val);
+}
+
+#[inline(always)]
+unsafe fn rfend_read(off: usize) -> u32 {
+    read_volatile((RFEND_BASE + off) as *const u32)
+}
+#[inline(always)]
+unsafe fn rfend_write(off: usize, val: u32) {
+    write_volatile((RFEND_BASE + off) as *mut u32, val);
+}
+
+// ── PLL / channel programming ─────────────────────────────────────────────────
+
+/// Program PLL for the given frequency (kHz) and set channel-lock bit.
+///
+/// From RF_DevSetChannel() in libwchble.a V1.40 using gptrRFENDReg (0x40025000):
+///   int_div  = (freq_khz / 64000) & 0x1F       → RFEND+0x44 bits[24:20]
+///   frac_div = (freq_khz % 64000) * 1024 / 250  → RFEND+0x44 bits[13:0]
+///   channel-lock bit1 set in RFEND+0x2C after PLL write.
+unsafe fn set_channel_freq(freq_khz: u32) {
+    let int_div = (freq_khz / 64000) & 0x1F;
+    let frac_div = ((freq_khz % 64000) << 10) / 250;
+
+    let pll = rfend_read(0x44);
+    let pll = (pll & 0xFE0F_C000) | (int_div << 20) | (frac_div & 0x3FFF);
+    rfend_write(0x44, pll);
+
+    let v = rfend_read(0x2C);
+    rfend_write(0x2C, v | (1 << 1));
+}
+
+// ── TX buffer (static, in .bss) ──────────────────────────────────────────────
+
+/// Raw PDU buffer: [0]=header0, [1]=header1, [2..38]=payload.
+static mut TX_BUF: [u8; 39] = [0u8; 39];
+
+/// Fill TX_BUF with a DTM test PDU.
+/// packet_type: 0=PRBS9, 1=0x0F repeated, 2=0x55 repeated, 3=vendor
+unsafe fn build_dtm_pdu(packet_type: u8, payload_len: u8) {
+    let len = payload_len.min(37);
+    TX_BUF[0] = ((packet_type & 0x3) << 6) | (len & 0x3F);
+    TX_BUF[1] = 0x00;
+    let fill = match packet_type {
+        1 => 0x0F,
+        2 => 0x55,
+        _ => 0xAA,
+    };
+    for i in 0..len as usize {
+        TX_BUF[2 + i] = fill;
+    }
+}
+
+// ── DTM TX trigger ───────────────────────────────────────────────────────────
+
+/// Trigger one DTM TX burst on the given frequency (kHz).
+unsafe fn dtm_tx_burst(freq_khz: u32) {
+    // 1. Arm TX mode: gptrBBReg+0x2C bits[1:0] = 01.
+    let lle_cfg = lle_read(0x2C);
+    lle_write(0x2C, (lle_cfg & !0x3) | 0x1);
+
+    // 2. Set LLE event timeout: gptrLLEReg+0x64 = 160.
+    bb_write(0x64, 160);
+
+    // 3. Program PLL and set channel-lock (gptrRFENDReg+0x44, +0x2C).
+    set_channel_freq(freq_khz);
+
+    // 4. TX path select: gptrBBReg+0x00 clear bits[8:7], set bit8.
+    let ctrl = lle_read(0x00);
+    lle_write(0x00, ctrl & !0x180);
+    let ctrl = lle_read(0x00);
+    lle_write(0x00, (ctrl & !0x180) | 0x100);
+
+    // 5. Enable PA bias: gptrRFENDReg+0x08 |= 0x330000.
+    let ana = rfend_read(0x08);
+    rfend_write(0x08, ana | 0x0033_0000);
+
+    // 6. TX pre-delay timer: gptrLLEReg+0x50 = 90.
+    bb_write(0x50, 90);
+
+    // 7. Release channel lock: gptrRFENDReg+0x2C bit1 = 0.
+    let v = rfend_read(0x2C);
+    rfend_write(0x2C, v & !(1 << 1));
+
+    // 8. Channel index: gptrBBReg+0x00 bits[6:0] = (freq_MHz - 2402) / 2.
+    let channel = (freq_khz / 1000 - 2402) / 2;
+    let ctrl = lle_read(0x00);
+    lle_write(0x00, (ctrl & !0x7F) | (channel & 0x7F));
+
+    // 9. Access Address: gptrBBReg+0x08.
+    lle_write(0x08, DTM_ACCESS_ADDR);
+
+    // 10. CRC init: gptrBBReg+0x04.
+    lle_write(0x04, DTM_CRC_INIT);
+
+    // 11. TX buffer pointer: gptrLLEReg+0x70.
+    bb_write(0x70, addr_of!(TX_BUF) as u32);
+
+    // 11.5. Write 2 to gptrLLEReg+0x00 (0x40024200) to arm the LLE in TX mode.
+    // From ll_tx_wait_finish in dtm.elf: writes value 2 to *(gptrLLEReg) immediately
+    // before the GO strobe. LLE+0x00 is a command/status register: bit1=TX active,
+    // bit3=shutdown handshake. Without this write the LLE ignores the GO pulse.
+    bb_write(0x00, 2);
+
+    // 12. GO bit: gptrBBReg+0x00 — clear then set to guarantee 0→1 edge trigger.
+    // bb_dev_init sets bit11=1; if GO is edge-triggered, that initial set consumes
+    // the edge and subsequent |=0x800 is a no-op. Clearing first ensures a real edge.
+    let ctrl = lle_read(0x00);
+    lle_write(0x00, ctrl & !0x800); // clear GO
+    let ctrl = lle_read(0x00);
+    lle_write(0x00, ctrl | 0x800);  // set GO (0→1 edge)
+
+    // 13. Clear TX arm: gptrBBReg+0x2C bits[1:0] = 00.
+    let lle_cfg = lle_read(0x2C);
+    lle_write(0x2C, lle_cfg & !0x3);
+}
+
+/// Poll for TX done at gptrLLEReg+0x08 (0x40024208, W1C IRQ status).
+/// Hardware fires IRQ bits 29+25 (0x22000000) on TX completion — docs showed bit2
+/// but live observation shows upper bits. Write all-ones to clear (W1C).
+unsafe fn wait_tx_done() -> bool {
+    for _ in 0..10_000u32 {
+        if bb_read(0x08) != 0 {
+            bb_write(0x08, 0xFFFF_FFFF);
+            return true;
+        }
+        riscv::asm::nop();
+    }
+    bb_write(0x08, 0xFFFF_FFFF);
+    false
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────────
+
+#[qingke_rt::entry]
+fn main() -> ! {
+    hal::debug::SDIPrint::enable();
+    let _p = hal::init(Default::default());
+
+    hal::println!("BLE DTM TX — CH32V208");
+    hal::println!("channels: 2406 / 2440 / 2472 MHz (DTM ch2/19/35)");
+
+    unsafe {
+        hal::ble::ble_phy_init();
+
+        build_dtm_pdu(2, 37);
+
+        hal::println!("PHY init done, starting TX loop");
+
+        // Dump initial register state once to confirm init values.
+        // ctrl bit28 must be 1 (0x10000000) — BB hardware enable from BB_DevInit.
+        hal::println!(
+            "INIT ctrl={:#010x} state={:#04x} irq={:#010x} cfg={:#010x} rfend2c={:#010x}",
+            lle_read(0x00), bb_read(0x1C), bb_read(0x08),
+            lle_read(0x2C), rfend_read(0x2C)
+        );
+        hal::println!("ctrl_bit28={} (expect 1)", (lle_read(0x00) >> 28) & 1);
+        hal::println!("cfg={:#010x} (expect 0x92010ec8)", lle_read(0x2C));
+
+        // DTM ch2/19/35 = 2406/2440/2472 MHz — avoid busy BLE adv channels.
+        const CHANNELS: [u32; 3] = [2_406_000, 2_440_000, 2_472_000];
+        let mut idx = 0usize;
+        let mut ok_count = 0u32;
+        let mut timeout_count = 0u32;
+        let mut total = 0u32;
+
+        loop {
+            let ctrl_pre = lle_read(0x00);
+
+            dtm_tx_burst(CHANNELS[idx]);
+
+            // Tight read immediately after GO — catches transient state transitions.
+            let ctrl_go = lle_read(0x00);   // CTRL after GO (bit11 may have auto-cleared)
+            let irq_go  = bb_read(0x08);    // IRQ status right after GO
+            let state_go = bb_read(0x1C);   // LLE state right after GO
+
+            let done = wait_tx_done();
+            let irq_after = bb_read(0x08);
+            let state_after = bb_read(0x1C);
+
+            if done { ok_count += 1; } else { timeout_count += 1; }
+            total += 1;
+
+            // Full register dump for first 5 bursts and every 300 thereafter.
+            if total <= 5 || total % 300 == 0 {
+                hal::println!(
+                    "#{} ok={} to={} ctrl:{:#010x}->{:#010x} irq_go={:#06x} state:{:#04x}->{:#04x} irq={:#010x}",
+                    total, ok_count, timeout_count,
+                    ctrl_pre, ctrl_go, irq_go, state_go, state_after, irq_after
+                );
+            }
+
+            idx = (idx + 1) % CHANNELS.len();
+
+            // ~625 µs at 32 MHz (1 BLE slot).
+            riscv::asm::delay(20_000);
+        }
+    }
+}

--- a/examples/ch32v208/src/bin/ble_dtm_tx.rs
+++ b/examples/ch32v208/src/bin/ble_dtm_tx.rs
@@ -221,6 +221,17 @@ fn main() -> ! {
     hal::println!("channels: 2406 / 2440 / 2472 MHz (DTM ch2/19/35)");
 
     unsafe {
+        // ── RCC / clock sanity check (before BLE init) ───────────────────────
+        // CTLR(+0x00): bit1=HSIRDY, bit17=HSERDY, bit25=PLLRDY
+        // CFGR0(+0x04): bits[3:2]=SWS (00=HSI, 01=HSE, 10=PLL)
+        let rcc_ctlr  = core::ptr::read_volatile(0x4002_1000 as *const u32);
+        let rcc_cfgr0 = core::ptr::read_volatile(0x4002_1004 as *const u32);
+        hal::println!("RCC: ctlr={:#010x} cfgr0={:#010x} hsirdy={} hserdy={} pllrdy={} sws={}",
+            rcc_ctlr, rcc_cfgr0,
+            (rcc_ctlr >> 1) & 1, (rcc_ctlr >> 17) & 1,
+            (rcc_ctlr >> 25) & 1, (rcc_cfgr0 >> 2) & 3);
+        hal::println!("  (hserdy must=1, pllrdy must=1, sws must=2 for 144MHz PLL)");
+
         hal::ble::ble_phy_init();
 
         build_dtm_pdu(2, 37);

--- a/src/ble/adv.rs
+++ b/src/ble/adv.rs
@@ -53,12 +53,8 @@ const ADV_CRC_INIT: u32 = 0x55_5555;
 /// PDU type: ADV_NONCONN_IND (non-connectable undirected, type=0b0010).
 const PDU_TYPE_ADV_NONCONN_IND: u8 = 0b0010;
 
-/// Advertising channels: ch37=2402 MHz, ch38=2426 MHz, ch39=2480 MHz.
-const ADV_CHANNELS: [(u8, u32); 3] = [
-    (37, 2_402_000),
-    (38, 2_426_000),
-    (39, 2_480_000),
-];
+/// Advertising channels: (index, freq_kHz). BLE spec Vol 6 §4.4.2.
+const ADV_CHANNELS: [(u8, u32); 3] = [(37, 2_402_000), (38, 2_426_000), (39, 2_480_000)];
 
 // ── TX buffer ─────────────────────────────────────────────────────────────────────────────────
 
@@ -130,85 +126,135 @@ pub fn ad_complete_name<'a>(buf: &'a mut [u8], name: &[u8]) -> usize {
 
 /// Trigger one ADV_NONCONN_IND burst on the given advertising channel.
 ///
-/// `ch_idx`: BLE channel index (37/38/39).
-/// `freq_khz`: corresponding frequency in kHz (2402000/2426000/2480000).
-unsafe fn adv_tx_burst(ch_idx: u8, freq_khz: u32) {
-    // 1. Arm TX mode: LLE+0x2C bits[1:0] = 01.
+/// Returns (state_pre_go, state_post_go, irq_post_go) — snapshot from immediately
+/// around the GO strobe for state-machine diagnostics.
+///
+/// state_pre/post_go: BB+0x1C (gptrLLEReg+0x1C) LLE state machine value.
+///   108 = Sleep (default), non-108 = hardware accepted GO and is processing.
+/// irq_post_go: BB+0x08 bits[15:0] immediately after GO; non-zero = TX IRQ fired
+///   (bits 29+25 = 0x22000000 are always-set hardware constants, masked out here).
+unsafe fn adv_tx_burst(ch_idx: u8, freq_khz: u32) -> (u32, u32, u32) {
+    // 1. TX arm: LLE+0x2C bits[1:0] = 01.
     let cfg = lle_read(0x2C);
     lle_write(0x2C, (cfg & !0x3) | 0x1);
 
-    // 2. Event timeout: BB+0x64 = 160.
+    // 2. Event timeout counter: BB+0x64 = 160.
     bb_write(0x64, 160);
 
-    // 3. PLL program + channel lock.
-    // From RF_DevSetChannel in libwchble.a V1.40 (confirmed by DTM TX at 2406/2440/2472 MHz).
+    // 3. PLL program for ADV channel (DTM-style: RFEND_CAL+0x44).
+    // Lucy confirmed ll_advertise_tx doesn't call this, but the calling context might expect
+    // PLL to be pre-programmed. We use the ADV non-DTM formula: freq_offset = freq-1000.
     {
-        let int_div = (freq_khz / 64_000) & 0x1F;
-        let frac_div = ((freq_khz % 64_000) << 10) / 250;
+        let freq_offset = freq_khz - 1_000;
+        let int_div = (freq_offset / 64_000) & 0x1F;
+        let frac_div = ((freq_offset % 64_000) << 10) / 250;
         let pll = read_volatile((RFEND_CAL_BASE + 0x44) as *const u32);
-        let pll = (pll & 0xFE0F_C000) | (int_div << 20) | (frac_div & 0x3FFF);
+        let pll = (pll & 0xFE0C_0000) | (int_div << 20) | (frac_div & 0x3_FFFF);
         write_volatile((RFEND_CAL_BASE + 0x44) as *mut u32, pll);
         let v = read_volatile((RFEND_CAL_BASE + 0x2C) as *const u32);
-        write_volatile((RFEND_CAL_BASE + 0x2C) as *mut u32, v | (1 << 1));
+        write_volatile((RFEND_CAL_BASE + 0x2C) as *mut u32, v | (1 << 1)); // set lock
     }
 
-    // 4. TX path select: LLE+0x00 clear bits[8:7], set bit8.
+    // 4. TX path select: LLE+0x00 clear bits[8:7] then set bit8.
     let ctrl = lle_read(0x00);
     lle_write(0x00, ctrl & !0x180);
     let ctrl = lle_read(0x00);
     lle_write(0x00, (ctrl & !0x180) | 0x100);
 
-    // 5. PA bias: RFEND+0x08 |= 0x330000.
+    // 5. PA bias: RFEND_CAL+0x08 |= 0x330000.
     let ana = read_volatile((RFEND_CAL_BASE + 0x08) as *const u32);
     write_volatile((RFEND_CAL_BASE + 0x08) as *mut u32, ana | 0x0033_0000);
 
     // 6. TX pre-delay: BB+0x50 = 90.
     bb_write(0x50, 90);
 
-    // 7. Release channel lock: RFEND+0x2C bit1 = 0.
+    // 7. Release channel lock: RFEND_CAL+0x2C bit1 = 0.
     let v = read_volatile((RFEND_CAL_BASE + 0x2C) as *const u32);
     write_volatile((RFEND_CAL_BASE + 0x2C) as *mut u32, v & !(1 << 1));
 
-    // 8. Channel index + whitening enable: LLE+0x00 bits[6:0] = (ch_idx & 0x3F) | 0x40.
-    // bit6=1 enables the BB hardware whitener and seeds its LFSR with {1, ch[5:0]}.
-    // (RF_DevSetChannel d.asm 71418; DTM writes only ch_idx & 0x7F, leaving bit6=0.)
+    // 8. Channel index + whitening enable: LLE+0x00 bits[6:0].
+    // bit6=1 enables BB hardware whitener (BLE spec Vol 6 §3.2, seed={1, ch[5:0]}).
+    // HW uses a LUT from this field for PLL freq select (confirmed Phase 1 SDR: HW output
+    // matched LLE+0x00 channel despite 14-bit PLL formula producing garbage RFEND values).
     let ctrl = lle_read(0x00);
     lle_write(0x00, (ctrl & !0x7F) | ((ch_idx as u32 & 0x3F) | 0x40));
 
     // 9. Access address: LLE+0x08 = ADV AA.
     lle_write(0x08, ADV_ACCESS_ADDR);
 
-    // 10. CRC init: LLE+0x04.
+    // 10. CRC init: LLE+0x04 = 0x555555.
     lle_write(0x04, ADV_CRC_INIT);
 
     // 11. TX buffer pointer: BB+0x70.
     bb_write(0x70, core::ptr::addr_of!(ADV_TX_BUF) as u32);
 
-    // 12. LLE arm: BB+0x00 = 2.
+    // 12. LLE arm: BB+0x00 = 2 — MUST come before GO bit.
+    // DTM comment: "Without this write the LLE ignores the GO pulse."
     bb_write(0x00, 2);
 
-    // 13. GO bit: LLE+0x00 clear then set (guaranteed 0→1 edge).
+    // Pre-GO: clear all BB+0x08 IRQ bits (full 32-bit W1C, same as DTM code).
+    // Bits 29+25 (0x22000000) are set by GO when TX fires; clearing here lets irq_post
+    // detect TX fire on a per-channel basis (if they are W1C-able at 32-bit width).
+    bb_write(0x08, 0xFFFF_FFFF);
+    let state_pre = bb_read(0x1C); // LLE state before GO; should be 108=Sleep
+
+    // 13. GO bit: LLE+0x00 |= 0x800. Clear first to guarantee 0→1 edge.
     let ctrl = lle_read(0x00);
     lle_write(0x00, ctrl & !0x800);
     let ctrl = lle_read(0x00);
     lle_write(0x00, ctrl | 0x800);
 
+    // Snapshot immediately after GO — before step 14 clears the arm.
+    // If state_post != state_pre: HW state machine accepted the GO command.
+    // If irq_post & 0xFFFF != 0: TX completion IRQ already fired.
+    let state_post = bb_read(0x1C);
+    let irq_post = bb_read(0x08);
+
     // 14. Clear TX arm: LLE+0x2C bits[1:0] = 00.
     let cfg = lle_read(0x2C);
     lle_write(0x2C, cfg & !0x3);
+
+    (state_pre, state_post, irq_post)
 }
 
-/// Poll for TX done (same as DTM: IRQ bits 29+25 = 0x22000000 at BB+0x08, W1C).
-unsafe fn wait_adv_tx_done() -> bool {
+/// Poll for TX completion — DTM-style.
+///
+/// BB+0x64 is event-driven and does not decrement in our TX mode (stays at 160).
+/// BB+0x08 bits 29+25 (0x22000000) are SET by the GO strobe when TX fires, matching
+/// the DTM TX behavior (confirmed: DTM INIT irq=0x00000000, after first GO irq=0x22000000).
+/// These bits are not clearable via W1C, so they remain set permanently.
+///
+/// After detecting TX fire via BB+0x08 != 0, we spin for ~350µs to allow the over-the-air
+/// packet to fully transmit before moving to the next advertising channel.
+///
+/// Returns (completed: bool, bb64_initial: u32, bb64_final: u32, bb08_final: u32).
+unsafe fn wait_adv_tx_done() -> (bool, u32, u32, u32) {
+    let initial = bb_read(0x64);
+    // Wait for TX fire indicator: BB+0x08 != 0 (bits 29+25 set by GO strobe).
     for _ in 0..10_000u32 {
         if bb_read(0x08) != 0 {
-            bb_write(0x08, 0xFFFF_FFFF);
-            return true;
+            // TX fired. Spin ~350µs at 144 MHz for over-the-air packet completion.
+            // ADV_NONCONN_IND packet @ 1 Mbps ≈ 240µs + pre-delay 90µs = 330µs.
+            for _ in 0..50_000u32 {
+                core::hint::spin_loop();
+            }
+            return (true, initial, bb_read(0x64), bb_read(0x08));
         }
         core::hint::spin_loop();
     }
-    bb_write(0x08, 0xFFFF_FFFF);
-    false
+    (false, initial, bb_read(0x64), bb_read(0x08))
+}
+
+// ── Diagnostic helpers ────────────────────────────────────────────────────────────────────────
+
+/// Read key registers for diagnostic logging.
+/// Returns (lle_2c, bb04_armed, lle_ctrl).
+/// Call immediately after `adv_tx_burst` / `adv_event` for a snapshot.
+pub unsafe fn diag_read() -> (u32, u32, u32) {
+    let lle_2c = lle_read(0x2C);      // channel field bits[30:25], TX arm bits[1:0]
+    let bb04 = bb_read(0x04);         // TX armed flag bit0
+    let ctrl = lle_read(0x00);        // channel bits[6:0] + whitening bit6 + GO bit11
+    (lle_2c, bb04, ctrl)
 }
 
 // ── Public API ───────────────────────────────────────────────────────────────────────────────
@@ -218,15 +264,27 @@ unsafe fn wait_adv_tx_done() -> bool {
 /// Must call `ble_phy_init()` before this.
 /// `addr`, `addr_is_random`, `adv_data`: forwarded to `build_adv_pdu`.
 ///
-/// Returns number of channels on which TX completed without timeout (0-3).
-pub unsafe fn adv_event(addr: &[u8; 6], addr_is_random: bool, adv_data: &[u8]) -> u8 {
+/// Returns:
+///   ok_count: number of channels where TX completed (0-3).
+///   stats: per-channel tuple (bb64_init, bb64_final, irq_final, state_pre, state_post, irq_post_go).
+///     state_pre/post: LLE state machine (108=Sleep); non-108 post means HW accepted GO.
+///     irq_post_go: BB+0x08 bits[15:0] immediately after GO; non-zero = IRQ fired fast.
+pub unsafe fn adv_event_verbose(addr: &[u8; 6], addr_is_random: bool, adv_data: &[u8])
+    -> (u8, [(u32, u32, u32, u32, u32, u32); 3])
+{
     build_adv_pdu(addr, addr_is_random, adv_data);
     let mut ok = 0u8;
-    for (ch_idx, freq_khz) in ADV_CHANNELS {
-        adv_tx_burst(ch_idx, freq_khz);
-        if wait_adv_tx_done() {
-            ok += 1;
-        }
+    let mut stats = [(0u32, 0u32, 0u32, 0u32, 0u32, 0u32); 3];
+    for (i, (ch_idx, freq_khz)) in ADV_CHANNELS.iter().enumerate() {
+        let (state_pre, state_post, irq_post) = adv_tx_burst(*ch_idx, *freq_khz);
+        let (done, init, fin, irq_final) = wait_adv_tx_done();
+        stats[i] = (init, fin, irq_final, state_pre, state_post, irq_post);
+        if done { ok += 1; }
     }
+    (ok, stats)
+}
+
+pub unsafe fn adv_event(addr: &[u8; 6], addr_is_random: bool, adv_data: &[u8]) -> u8 {
+    let (ok, _) = adv_event_verbose(addr, addr_is_random, adv_data);
     ok
 }

--- a/src/ble/adv.rs
+++ b/src/ble/adv.rs
@@ -135,8 +135,12 @@ pub fn ad_complete_name<'a>(buf: &'a mut [u8], name: &[u8]) -> usize {
 ///   (bits 29+25 = 0x22000000 are always-set hardware constants, masked out here).
 unsafe fn adv_tx_burst(ch_idx: u8, freq_khz: u32) -> (u32, u32, u32) {
     // 1. TX arm: LLE+0x2C bits[1:0] = 01.
+    //    Also update LLE+0x2C bits[30:25] = ch_idx (channel field used by HW for whitening/CRC LUT).
+    //    bb_dev_init leaves this at 9; without this write all ADV channels would use channel-9
+    //    whitening instead of the actual channel (37/38/39), causing CRC failure on receivers.
     let cfg = lle_read(0x2C);
-    lle_write(0x2C, (cfg & !0x3) | 0x1);
+    let cfg = (cfg & 0x81FF_FFFF) | ((ch_idx as u32 & 0x3F) << 25) | 0x1;
+    lle_write(0x2C, cfg);
 
     // 2. Event timeout counter: BB+0x64 = 160.
     bb_write(0x64, 160);
@@ -173,11 +177,16 @@ unsafe fn adv_tx_burst(ch_idx: u8, freq_khz: u32) -> (u32, u32, u32) {
     write_volatile((RFEND_CAL_BASE + 0x2C) as *mut u32, v & !(1 << 1));
 
     // 8. Channel index + whitening enable: LLE+0x00 bits[6:0].
+    // bits[5:0] = PHYSICAL frequency-offset index for PLL LUT (same formula as DTM):
+    //   phys_idx = (freq_MHz - 2402) / 2
+    //   ch37=2402 → 0,  ch38=2426 → 12,  ch39=2480 → 39
+    // This is NOT the logical BLE channel number (37/38/39)!  Writing ch_idx=37 here would
+    // select physical index 37 → 2402+74=2476 MHz instead of 2402 MHz.
     // bit6=1 enables BB hardware whitener (BLE spec Vol 6 §3.2, seed={1, ch[5:0]}).
-    // HW uses a LUT from this field for PLL freq select (confirmed Phase 1 SDR: HW output
-    // matched LLE+0x00 channel despite 14-bit PLL formula producing garbage RFEND values).
+    // Whitening LFSR seed uses LLE+0x2C bits[30:25] (= ch_idx, set in step 1), not this field.
+    let phys_idx = (freq_khz / 1_000 - 2_402) / 2;
     let ctrl = lle_read(0x00);
-    lle_write(0x00, (ctrl & !0x7F) | ((ch_idx as u32 & 0x3F) | 0x40));
+    lle_write(0x00, (ctrl & !0x7F) | ((phys_idx & 0x3F) | 0x40));
 
     // 9. Access address: LLE+0x08 = ADV AA.
     lle_write(0x08, ADV_ACCESS_ADDR);
@@ -217,32 +226,19 @@ unsafe fn adv_tx_burst(ch_idx: u8, freq_khz: u32) -> (u32, u32, u32) {
     (state_pre, state_post, irq_post)
 }
 
-/// Poll for TX completion — DTM-style.
+/// Poll for ADV TX completion.
 ///
-/// BB+0x64 is event-driven and does not decrement in our TX mode (stays at 160).
-/// BB+0x08 bits 29+25 (0x22000000) are SET by the GO strobe when TX fires, matching
-/// the DTM TX behavior (confirmed: DTM INIT irq=0x00000000, after first GO irq=0x22000000).
-/// These bits are not clearable via W1C, so they remain set permanently.
+/// Delegates to `ble_tx_wait_done` — the shared BLE TX completion primitive.
+/// See `crate::ble::ble_tx_wait_done` for the full signal description.
 ///
-/// After detecting TX fire via BB+0x08 != 0, we spin for ~350µs to allow the over-the-air
-/// packet to fully transmit before moving to the next advertising channel.
+/// settle_loops ≈ 350µs at 144 MHz (50_000 spin_loop iterations):
+///   ADV_NONCONN_IND @ 1 Mbps ≈ 240µs + BB+0x50 pre-delay 90µs = 330µs.
 ///
 /// Returns (completed: bool, bb64_initial: u32, bb64_final: u32, bb08_final: u32).
 unsafe fn wait_adv_tx_done() -> (bool, u32, u32, u32) {
     let initial = bb_read(0x64);
-    // Wait for TX fire indicator: BB+0x08 != 0 (bits 29+25 set by GO strobe).
-    for _ in 0..10_000u32 {
-        if bb_read(0x08) != 0 {
-            // TX fired. Spin ~350µs at 144 MHz for over-the-air packet completion.
-            // ADV_NONCONN_IND packet @ 1 Mbps ≈ 240µs + pre-delay 90µs = 330µs.
-            for _ in 0..50_000u32 {
-                core::hint::spin_loop();
-            }
-            return (true, initial, bb_read(0x64), bb_read(0x08));
-        }
-        core::hint::spin_loop();
-    }
-    (false, initial, bb_read(0x64), bb_read(0x08))
+    let done = super::ble_tx_wait_done(10_000, 50_000);
+    (done, initial, bb_read(0x64), bb_read(0x08))
 }
 
 // ── Diagnostic helpers ────────────────────────────────────────────────────────────────────────

--- a/src/ble/adv.rs
+++ b/src/ble/adv.rs
@@ -1,0 +1,232 @@
+// BLE advertising for CH32V208 — ADV_NONCONN_IND (non-connectable undirected).
+//
+// Spec ref: BLE Core Spec Vol 6 Part B §2.3 (PDU), Vol 6 Part B §4.4.2 (advertising channels).
+//
+// PDU layout (over the air, LSB first):
+//   Preamble (1B, hw) | AA 0x8E89BED6 (4B) | Header (2B) | AdvA (6B) | AdvData (0-31B) | CRC-24 (3B, hw)
+//
+// BB hardware handles: preamble, CRC-24 (init 0x555555), and whitening.
+// SW provides: header, AdvA, AdvData in TX buffer.
+//
+// Whitening: enabled by setting bit6 of LLE+0x00 alongside the channel index.
+// BB hardware seeds its whitening LFSR from LLE+0x00 bits[6:0] = {1, ch[5:0]},
+// which matches BLE spec Vol 6 Part B §3.2 (LFSR position 6 = 1, positions[5:0] = channel).
+// Source: RF_DevSetChannel in d.asm line 71418 (Lucy's Phase 2 cheat sheet 2026-04-30).
+// DTM leaves bit6=0 (no whitening), per DTM spec Vol 6 Part F.
+
+use core::ptr::{read_volatile, write_volatile};
+
+// ── Register bases (same as dtm example, confirmed from BLE_IPCoreInit in dtm.elf) ──────────
+
+/// gptrBBReg: link-layer CTRL/GO, TX mode, ACCESS_ADDR, CRC_INIT.
+const LLE_BASE: usize = 0x40024100;
+/// gptrLLEReg: timing params, IRQ status/mask, TX timer, TX buffer pointer.
+const BB_BASE: usize = 0x40024200;
+/// gptrRFENDReg: PLL dividers, channel lock, PA bias. Distinct from rfend.rs (0x40024300).
+const RFEND_CAL_BASE: usize = 0x40025000;
+
+#[inline(always)]
+unsafe fn lle_read(off: usize) -> u32 {
+    read_volatile((LLE_BASE + off) as *const u32)
+}
+#[inline(always)]
+unsafe fn lle_write(off: usize, val: u32) {
+    write_volatile((LLE_BASE + off) as *mut u32, val);
+}
+#[inline(always)]
+unsafe fn bb_read(off: usize) -> u32 {
+    read_volatile((BB_BASE + off) as *const u32)
+}
+#[inline(always)]
+unsafe fn bb_write(off: usize, val: u32) {
+    write_volatile((BB_BASE + off) as *mut u32, val);
+}
+
+// ── BLE advertising constants ─────────────────────────────────────────────────────────────────
+
+/// Advertising access address (fixed by BLE spec for all advertising channels).
+const ADV_ACCESS_ADDR: u32 = 0x8E89_BED6;
+
+/// CRC initial value for advertising (BLE spec Vol 6 Part B §3.1.1).
+const ADV_CRC_INIT: u32 = 0x55_5555;
+
+/// PDU type: ADV_NONCONN_IND (non-connectable undirected, type=0b0010).
+const PDU_TYPE_ADV_NONCONN_IND: u8 = 0b0010;
+
+/// Advertising channels: ch37=2402 MHz, ch38=2426 MHz, ch39=2480 MHz.
+const ADV_CHANNELS: [(u8, u32); 3] = [
+    (37, 2_402_000),
+    (38, 2_426_000),
+    (39, 2_480_000),
+];
+
+// ── TX buffer ─────────────────────────────────────────────────────────────────────────────────
+
+/// Maximum AdvData length (BLE spec Vol 6 Part B §2.3.1.4).
+pub const ADV_DATA_MAX: usize = 31;
+
+/// TX buffer: header (2B) + AdvA (6B) + AdvData (up to 31B).
+static mut ADV_TX_BUF: [u8; 2 + 6 + ADV_DATA_MAX] = [0u8; 2 + 6 + ADV_DATA_MAX];
+
+// ── PDU builder ──────────────────────────────────────────────────────────────────────────────
+
+/// Build an ADV_NONCONN_IND PDU into `ADV_TX_BUF`.
+///
+/// `addr`: 6-byte device address (LE order, as stored in hardware address registers).
+/// `addr_is_random`: true = random address (TxAdd=1), false = public (TxAdd=0).
+/// `adv_data`: AD structure bytes (max 31B). Must be pre-formatted AD structures.
+///
+/// Returns the total PDU length in bytes (header + AdvA + adv_data).
+pub unsafe fn build_adv_pdu(addr: &[u8; 6], addr_is_random: bool, adv_data: &[u8]) -> usize {
+    let adv_len = adv_data.len().min(ADV_DATA_MAX);
+    let payload_len = 6 + adv_len; // AdvA(6) + AdvData
+
+    // Header byte 0: PDU type | RFU(2b) | ChSel(1b) | TxAdd | RxAdd
+    // ADV_NONCONN_IND: ChSel=0, RxAdd=0, TxAdd from addr_is_random.
+    let txadd: u8 = if addr_is_random { 1 << 6 } else { 0 };
+    ADV_TX_BUF[0] = PDU_TYPE_ADV_NONCONN_IND | txadd;
+    // Header byte 1: Length field (6-bit, value = payload_len).
+    ADV_TX_BUF[1] = payload_len as u8 & 0x3F;
+
+    // AdvA: device address, 6 bytes LE.
+    ADV_TX_BUF[2..8].copy_from_slice(addr);
+
+    // AdvData: AD structures.
+    ADV_TX_BUF[8..8 + adv_len].copy_from_slice(&adv_data[..adv_len]);
+
+    2 + payload_len // total bytes used in TX buf
+}
+
+// ── AD structure helpers ─────────────────────────────────────────────────────────────────────
+
+/// Write Flags AD structure (type 0x01) into `buf`.
+/// Returns number of bytes written.
+/// Standard value: LE General Discoverable | BR/EDR Not Supported = 0x06.
+pub fn ad_flags(buf: &mut [u8], flags: u8) -> usize {
+    if buf.len() < 3 {
+        return 0;
+    }
+    buf[0] = 2; // length
+    buf[1] = 0x01; // type: Flags
+    buf[2] = flags;
+    3
+}
+
+/// Write Complete Local Name AD structure (type 0x09) into `buf`.
+/// Returns number of bytes written, truncated to fit.
+pub fn ad_complete_name<'a>(buf: &'a mut [u8], name: &[u8]) -> usize {
+    let max_name = buf.len().saturating_sub(2);
+    let name_len = name.len().min(max_name);
+    if name_len == 0 {
+        return 0;
+    }
+    buf[0] = (name_len + 1) as u8; // length
+    buf[1] = 0x09; // type: Complete Local Name
+    buf[2..2 + name_len].copy_from_slice(&name[..name_len]);
+    2 + name_len
+}
+
+// ── TX trigger ───────────────────────────────────────────────────────────────────────────────
+
+/// Trigger one ADV_NONCONN_IND burst on the given advertising channel.
+///
+/// `ch_idx`: BLE channel index (37/38/39).
+/// `freq_khz`: corresponding frequency in kHz (2402000/2426000/2480000).
+unsafe fn adv_tx_burst(ch_idx: u8, freq_khz: u32) {
+    // 1. Arm TX mode: LLE+0x2C bits[1:0] = 01.
+    let cfg = lle_read(0x2C);
+    lle_write(0x2C, (cfg & !0x3) | 0x1);
+
+    // 2. Event timeout: BB+0x64 = 160.
+    bb_write(0x64, 160);
+
+    // 3. PLL program + channel lock.
+    // From RF_DevSetChannel in libwchble.a V1.40 (confirmed by DTM TX at 2406/2440/2472 MHz).
+    {
+        let int_div = (freq_khz / 64_000) & 0x1F;
+        let frac_div = ((freq_khz % 64_000) << 10) / 250;
+        let pll = read_volatile((RFEND_CAL_BASE + 0x44) as *const u32);
+        let pll = (pll & 0xFE0F_C000) | (int_div << 20) | (frac_div & 0x3FFF);
+        write_volatile((RFEND_CAL_BASE + 0x44) as *mut u32, pll);
+        let v = read_volatile((RFEND_CAL_BASE + 0x2C) as *const u32);
+        write_volatile((RFEND_CAL_BASE + 0x2C) as *mut u32, v | (1 << 1));
+    }
+
+    // 4. TX path select: LLE+0x00 clear bits[8:7], set bit8.
+    let ctrl = lle_read(0x00);
+    lle_write(0x00, ctrl & !0x180);
+    let ctrl = lle_read(0x00);
+    lle_write(0x00, (ctrl & !0x180) | 0x100);
+
+    // 5. PA bias: RFEND+0x08 |= 0x330000.
+    let ana = read_volatile((RFEND_CAL_BASE + 0x08) as *const u32);
+    write_volatile((RFEND_CAL_BASE + 0x08) as *mut u32, ana | 0x0033_0000);
+
+    // 6. TX pre-delay: BB+0x50 = 90.
+    bb_write(0x50, 90);
+
+    // 7. Release channel lock: RFEND+0x2C bit1 = 0.
+    let v = read_volatile((RFEND_CAL_BASE + 0x2C) as *const u32);
+    write_volatile((RFEND_CAL_BASE + 0x2C) as *mut u32, v & !(1 << 1));
+
+    // 8. Channel index + whitening enable: LLE+0x00 bits[6:0] = (ch_idx & 0x3F) | 0x40.
+    // bit6=1 enables the BB hardware whitener and seeds its LFSR with {1, ch[5:0]}.
+    // (RF_DevSetChannel d.asm 71418; DTM writes only ch_idx & 0x7F, leaving bit6=0.)
+    let ctrl = lle_read(0x00);
+    lle_write(0x00, (ctrl & !0x7F) | ((ch_idx as u32 & 0x3F) | 0x40));
+
+    // 9. Access address: LLE+0x08 = ADV AA.
+    lle_write(0x08, ADV_ACCESS_ADDR);
+
+    // 10. CRC init: LLE+0x04.
+    lle_write(0x04, ADV_CRC_INIT);
+
+    // 11. TX buffer pointer: BB+0x70.
+    bb_write(0x70, core::ptr::addr_of!(ADV_TX_BUF) as u32);
+
+    // 12. LLE arm: BB+0x00 = 2.
+    bb_write(0x00, 2);
+
+    // 13. GO bit: LLE+0x00 clear then set (guaranteed 0→1 edge).
+    let ctrl = lle_read(0x00);
+    lle_write(0x00, ctrl & !0x800);
+    let ctrl = lle_read(0x00);
+    lle_write(0x00, ctrl | 0x800);
+
+    // 14. Clear TX arm: LLE+0x2C bits[1:0] = 00.
+    let cfg = lle_read(0x2C);
+    lle_write(0x2C, cfg & !0x3);
+}
+
+/// Poll for TX done (same as DTM: IRQ bits 29+25 = 0x22000000 at BB+0x08, W1C).
+unsafe fn wait_adv_tx_done() -> bool {
+    for _ in 0..10_000u32 {
+        if bb_read(0x08) != 0 {
+            bb_write(0x08, 0xFFFF_FFFF);
+            return true;
+        }
+        core::hint::spin_loop();
+    }
+    bb_write(0x08, 0xFFFF_FFFF);
+    false
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────────────────────
+
+/// Send one complete advertising event: transmit ADV_NONCONN_IND on all 3 advertising channels.
+///
+/// Must call `ble_phy_init()` before this.
+/// `addr`, `addr_is_random`, `adv_data`: forwarded to `build_adv_pdu`.
+///
+/// Returns number of channels on which TX completed without timeout (0-3).
+pub unsafe fn adv_event(addr: &[u8; 6], addr_is_random: bool, adv_data: &[u8]) -> u8 {
+    build_adv_pdu(addr, addr_is_random, adv_data);
+    let mut ok = 0u8;
+    for (ch_idx, freq_khz) in ADV_CHANNELS {
+        adv_tx_burst(ch_idx, freq_khz);
+        if wait_adv_tx_done() {
+            ok += 1;
+        }
+    }
+    ok
+}

--- a/src/ble/adv.rs
+++ b/src/ble/adv.rs
@@ -177,16 +177,15 @@ unsafe fn adv_tx_burst(ch_idx: u8, freq_khz: u32) -> (u32, u32, u32) {
     write_volatile((RFEND_CAL_BASE + 0x2C) as *mut u32, v & !(1 << 1));
 
     // 8. Channel index + whitening enable: LLE+0x00 bits[6:0].
-    // bits[5:0] = PHYSICAL frequency-offset index for PLL LUT (same formula as DTM):
-    //   phys_idx = (freq_MHz - 2402) / 2
-    //   ch37=2402 → 0,  ch38=2426 → 12,  ch39=2480 → 39
-    // This is NOT the logical BLE channel number (37/38/39)!  Writing ch_idx=37 here would
-    // select physical index 37 → 2402+74=2476 MHz instead of 2402 MHz.
+    // bits[5:0] = LOGICAL BLE channel number (37/38/39 for ADV).
+    //   confirmed by Lucy's RE of ll_advertise_process (asm line 40091):
+    //     li a1, 37   ; hardcoded logical ch37, not phys_idx=0
+    //   and LL_ReceiverTest / LL_TransmitterTest: map phys_idx → logical, then write logical.
     // bit6=1 enables BB hardware whitener (BLE spec Vol 6 §3.2, seed={1, ch[5:0]}).
-    // Whitening LFSR seed uses LLE+0x2C bits[30:25] (= ch_idx, set in step 1), not this field.
-    let phys_idx = (freq_khz / 1_000 - 2_402) / 2;
+    // NOTE: DTM (ble_dtm_tx) writes phys_idx with bit6=0 (no whitening); the hardware
+    // uses a different LUT path when bit6=0 vs bit6=1.
     let ctrl = lle_read(0x00);
-    lle_write(0x00, (ctrl & !0x7F) | ((phys_idx & 0x3F) | 0x40));
+    lle_write(0x00, (ctrl & !0x7F) | ((ch_idx as u32 & 0x3F) | 0x40));
 
     // 9. Access address: LLE+0x08 = ADV AA.
     lle_write(0x08, ADV_ACCESS_ADDR);

--- a/src/ble/bb.rs
+++ b/src/ble/bb.rs
@@ -1,0 +1,57 @@
+// BB (Baseband) initialization for CH32V208 BLE.
+//
+// Register base: 0x40024200
+// Source: elec-docs/ble-reverse-docs/24-rf-phy-supplement.md
+// Derived from BB_DevInit() in libwchble.a V1.40 (bb.o, line 71369)
+
+use core::ptr::{read_volatile, write_volatile};
+
+const BB_BASE: usize = 0x40024200;
+
+#[inline(always)]
+unsafe fn bb_read(offset: usize) -> u32 {
+    read_volatile((BB_BASE + offset) as *const u32)
+}
+
+#[inline(always)]
+unsafe fn bb_write(offset: usize, val: u32) {
+    write_volatile((BB_BASE + offset) as *mut u32, val);
+}
+
+#[inline(always)]
+unsafe fn bb_modify(offset: usize, clear: u32, set: u32) {
+    let v = bb_read(offset);
+    bb_write(offset, (v & !clear) | set);
+}
+
+/// BB RF flag — selects 1M or 2M PHY path in BB_CFG.
+///
+/// Bit 0: 1M PHY enabled; other bits: extended PHY modes.
+/// Default 0 = 1M only. This is read from a global in libwchble; 0 matches
+/// standard BLE 1M advertising usage.
+pub const BB_RF_FLAG_1M: u8 = 0x00;
+
+/// Initialize the BB baseband processor.
+///
+/// Mirrors BB_DevInit() from libwchble.a V1.40 (bb.o, line 71369).
+/// Configures CTRL, TIMING, CFG, and MODE registers.
+///
+/// `rf_flag`: PHY mode selection. Use `BB_RF_FLAG_1M` for standard BLE 1M.
+pub unsafe fn bb_dev_init(rf_flag: u8) {
+    // CTRL (+0x00): set bit11 and bit20
+    bb_modify(0x00, 0x0000_0000, 0x0000_0800); // bit11 = 1
+    bb_modify(0x00, 0x0000_0000, 0x0010_0000); // bit20 = 1
+
+    // TIMING (+0x34): default 464 (0x1D0)
+    bb_write(0x34, 0x1D0);
+
+    // CFG (+0x2C): base value 0x80010EC8 ORed with rf_flag bits
+    // Base from: lui a2,0x80011; addi a2,-312 = 0x80010EC8
+    let cfg_base: u32 = 0x80010EC8;
+    let cfg_val = cfg_base | ((rf_flag as u32 & 0x3F) << 25);
+    bb_write(0x2C, cfg_val);
+
+    // MODE (+0x20): 0x90083
+    // From: lui a4,0x90; addi a4,131 = 0x90083
+    bb_write(0x20, 0x90083);
+}

--- a/src/ble/bb.rs
+++ b/src/ble/bb.rs
@@ -1,12 +1,13 @@
 // BB (Baseband) initialization for CH32V208 BLE.
 //
-// Register base: 0x40024200
+// Register base: 0x40024100 (gptrBBReg — CTRL, GO, ACCESS_ADDR, CRC_INIT, TX mode, CFG, MODE)
 // Source: elec-docs/ble-reverse-docs/24-rf-phy-supplement.md
 // Derived from BB_DevInit() in libwchble.a V1.40 (bb.o, line 71369)
 
 use core::ptr::{read_volatile, write_volatile};
 
-const BB_BASE: usize = 0x40024200;
+// gptrBBReg in WCH naming: link-layer CTRL, GO, ACCESS_ADDR, CRC_INIT, TX mode, CFG, MODE.
+const BB_BASE: usize = 0x40024100;
 
 #[inline(always)]
 unsafe fn bb_read(offset: usize) -> u32 {
@@ -24,12 +25,13 @@ unsafe fn bb_modify(offset: usize, clear: u32, set: u32) {
     bb_write(offset, (v & !clear) | set);
 }
 
-/// BB RF flag — selects 1M or 2M PHY path in BB_CFG.
+/// BB RF flag — PHY mode selection bits for BB_CFG bits[30:25] (= rf_flag << 25).
 ///
-/// Bit 0: 1M PHY enabled; other bits: extended PHY modes.
-/// Default 0 = 1M only. This is read from a global in libwchble; 0 matches
-/// standard BLE 1M advertising usage.
-pub const BB_RF_FLAG_1M: u8 = 0x00;
+/// Value 0x09 confirmed from live dtm.elf hardware dump:
+/// BB+0x2C (CFG) = 0x92010EC8 = 0x80010EC8 | (0x09 << 25).
+/// bit0=1M PHY enabled; bit3=additional PHY/feature (exact meaning TBD).
+/// Using 0x00 produces CFG=0x80010EC8, which differs from the reference firmware.
+pub const BB_RF_FLAG_1M: u8 = 0x09;
 
 /// Initialize the BB baseband processor.
 ///
@@ -38,9 +40,15 @@ pub const BB_RF_FLAG_1M: u8 = 0x00;
 ///
 /// `rf_flag`: PHY mode selection. Use `BB_RF_FLAG_1M` for standard BLE 1M.
 pub unsafe fn bb_dev_init(rf_flag: u8) {
-    // CTRL (+0x00): set bit11 and bit20
-    bb_modify(0x00, 0x0000_0000, 0x0000_0800); // bit11 = 1
-    bb_modify(0x00, 0x0000_0000, 0x0010_0000); // bit20 = 1
+    // CTRL (+0x00): set bit11 (GO strobe to clear any stale state) and bit20.
+    // bit11 is a GO strobe — the hardware auto-clears it after processing.
+    // We set it here to match BB_DevInit in libwchble, then clear it explicitly
+    // so it starts at 0 for subsequent TX bursts.
+    bb_modify(0x00, 0x0000_0000, 0x0000_0800); // bit11 = GO strobe
+    // bit28 = 0x10000000: hardware enable bit (confirmed from BB_DevInit in dtm.elf:
+    // `lui a3,0x10000` → or CTRL,CTRL,a3).  Previously wrong as bit20 (0x100000).
+    bb_modify(0x00, 0x0000_0000, 0x1000_0000); // bit28 = 1
+    bb_modify(0x00, 0x0000_0800, 0x0000_0000); // clear bit11 after strobe
 
     // TIMING (+0x34): default 464 (0x1D0)
     bb_write(0x34, 0x1D0);

--- a/src/ble/lle.rs
+++ b/src/ble/lle.rs
@@ -1,12 +1,13 @@
 // LLE (Link Layer Engine) initialization for CH32V208 BLE.
 //
-// Register base: 0x40024100
+// Register base: 0x40024200 (gptrLLEReg — timing, IRQ, timer, TX buf ptr)
 // Source: elec-docs/ble-reverse-docs/05-lle-engine.md and hardware dump
 // Hardware-confirmed timing values from live CH32V208WBU6 board dump.
 
 use core::ptr::{read_volatile, write_volatile};
 
-const LLE_BASE: usize = 0x40024100;
+// gptrLLEReg in WCH naming: timing, scheduling, IRQ status, timer, TX buffer.
+const LLE_BASE: usize = 0x40024200;
 
 #[inline(always)]
 unsafe fn lle_read(offset: usize) -> u32 {

--- a/src/ble/lle.rs
+++ b/src/ble/lle.rs
@@ -1,0 +1,86 @@
+// LLE (Link Layer Engine) initialization for CH32V208 BLE.
+//
+// Register base: 0x40024100
+// Source: elec-docs/ble-reverse-docs/05-lle-engine.md and hardware dump
+// Hardware-confirmed timing values from live CH32V208WBU6 board dump.
+
+use core::ptr::{read_volatile, write_volatile};
+
+const LLE_BASE: usize = 0x40024100;
+
+#[inline(always)]
+unsafe fn lle_read(offset: usize) -> u32 {
+    read_volatile((LLE_BASE + offset) as *const u32)
+}
+
+#[inline(always)]
+unsafe fn lle_write(offset: usize, val: u32) {
+    write_volatile((LLE_BASE + offset) as *mut u32, val);
+}
+
+/// LLE state machine values (observed from live hardware and assembly).
+#[repr(u8)]
+#[derive(Copy, Clone, Debug)]
+pub enum LleState {
+    /// No connection, waiting for RX.
+    ConnRxWait = 93,
+    /// Connection TX prepare.
+    ConnTxPrep = 97,
+    /// Connection ACK wait.
+    ConnAckWait = 101,
+    /// Connection event closing.
+    ConnEventClosing = 105,
+    /// Preparing for sleep.
+    SleepPrep = 107,
+    /// Sleep state (default after init).
+    Sleep = 108,
+}
+
+/// Initialize the LLE link layer engine.
+///
+/// Sets timing parameters from hardware-confirmed defaults, clears all
+/// pending IRQ status bits, and enables the standard IRQ mask (0xF00F).
+///
+/// Hardware-confirmed values from live CH32V208WBU6 board (STATE_MACHINE=108=SLEEP,
+/// TIMING0-7 matching values below) via wlink dump at +0x40024100.
+pub unsafe fn lle_dev_init() {
+    // Clear all pending IRQ status (W1C) before unmasking.
+    // Offset +0x08 is the IRQ_STATUS register (write-only path; read returns IRQ_STATUS,
+    // write is W1C). Writing 0xFFFF clears all 16 defined interrupt bits.
+    lle_write(0x08, 0xFFFF);
+
+    // Set IRQ mask: 0xF00F enables bits [15:12] and [3:0].
+    // Confirmed from libwchble assembly: LLE_IRQSubHandler checks bits 14,3,2,1,0.
+    lle_write(0x0C, 0xF00F);
+
+    // Timing parameters — all hardware-confirmed from live board dump.
+    lle_write(0x14, 140); // TIMING0
+    lle_write(0x24, 140); // TIMING2
+    lle_write(0x2C, 60);  // TIMING3
+    lle_write(0x34, 140); // TIMING4
+    lle_write(0x3C, 60);  // TIMING5
+    lle_write(0x44, 140); // TIMING6
+    lle_write(0x4C, 108); // TIMING7
+
+    // Initial state: SLEEP.
+    lle_write(0x1C, LleState::Sleep as u32);
+}
+
+/// Read the current LLE state machine value.
+pub unsafe fn lle_read_state() -> u8 {
+    (lle_read(0x1C) & 0xFF) as u8
+}
+
+/// Read the current IRQ status (unmasked raw status bits).
+///
+/// Note: +0x08 is a split register. CPU reads return IRQ_STATUS (live event bits);
+/// writes are W1C. Do not interpret read values as ACCESS_ADDR.
+/// See wchble disasm notes: real-hardware-verification chapter.
+pub unsafe fn lle_read_irq_status() -> u32 {
+    lle_read(0x08)
+}
+
+/// Clear specific LLE IRQ status bits (W1C).
+pub unsafe fn lle_clear_irq(bits: u32) {
+    lle_write(0x08, bits);
+}

--- a/src/ble/mod.rs
+++ b/src/ble/mod.rs
@@ -47,26 +47,19 @@ pub unsafe fn ble_phy_init() {
     let osc = osc | (3 << 24);
     core::ptr::write_volatile(OSC_HSE_CAL_CTRL, osc);
 
-    // RF frontend: reset then configure analog front end.
-    rfend_dev_init();
-
-    // Baseband processor: configure mode and timing.
-    bb_dev_init(bb::BB_RF_FLAG_1M);
-
-    // Link layer engine: configure timing params and IRQ mask.
+    // Init order from BLE_IPCoreInit in dtm.elf: LLE first, then RFEND, then BB.
+    // LLE must be initialized before BB_DevInit fires the GO strobe.
     lle_dev_init();
+    rfend_dev_init();
+    bb_dev_init(bb::BB_RF_FLAG_1M);
 
     // Enable CRC peripheral clock (required by BLE stack).
     let ahb = core::ptr::read_volatile(RCC_AHBPCENR);
     core::ptr::write_volatile(RCC_AHBPCENR, ahb | RCC_AHBPCENR_CRC_EN);
 
-    // Enable BB and LLE interrupts at the NVIC level.
-    // CH32V208: BB=IRQn 63, LLE=IRQn 64.
-    // PFIC IENR registers: IENR1 covers IRQ32-63, IENR2 covers IRQ64-95.
-    const PFIC_IENR1: *mut u32 = 0xE000_E100 as *mut u32; // IRQ 32-63
-    const PFIC_IENR2: *mut u32 = 0xE000_E104 as *mut u32; // IRQ 64-95
-    // BB IRQn 63 → bit 31 of IENR1
-    core::ptr::write_volatile(PFIC_IENR1, 1 << 31);
-    // LLE IRQn 64 → bit 0 of IENR2
-    core::ptr::write_volatile(PFIC_IENR2, 1 << 0);
+    // NOTE: BB (IRQn 63) and LLE (IRQn 64) interrupts are NOT enabled here.
+    // The DTM polling TX path reads IRQ status directly via register polling.
+    // Enabling IRQs without registered handlers causes unhandled exception faults.
+    // Applications that use interrupt-driven BLE (TMOS/BLE stack) must enable
+    // them separately after installing BB_IRQHandler / LLE_IRQHandler.
 }

--- a/src/ble/mod.rs
+++ b/src/ble/mod.rs
@@ -34,27 +34,36 @@ const GPTRLLE_BASE: usize = 0x40024200;
 /// Wait for a BLE TX burst to fire and settle, using the DTM-style completion signal.
 ///
 /// **Completion signal**: `BB+0x08` bits 29+25 (`0x2200_0000`) are set by the GO
-/// strobe when a TX burst fires. These bits are not W1C-clearable (sticky), so
-/// they only transition 0 → non-zero once per power cycle (at the first TX after
-/// reset). After the first TX they are permanently set; callers that need per-burst
-/// fire detection must clear `BB+0x08` with a full 32-bit W1C write before each GO.
+/// strobe when a TX burst fires. These bits are sticky (not W1C-clearable): they
+/// transition 0 → non-zero at the first TX after reset and remain set permanently.
 ///
-/// **BB+0x64 is NOT the indicator**: `gptrLLEReg+0x64` is event-driven and only
+/// **Timing contract**: this function MUST be called after the GO strobe has already
+/// been issued. For the first TX, it waits for the 0→non-zero transition; for all
+/// subsequent TXs, the bits are already set so it enters `settle_loops` immediately.
+/// In both cases `settle_loops` provides the real timing guarantee — it is the
+/// caller's responsibility to size it to cover the full over-the-air packet duration.
+///
+/// Per-burst fire detection: to observe whether each individual GO causes a new TX
+/// (e.g. for diagnostics), write `bb_write(0x08, 0xFFFF_FFFF)` before each GO.
+/// On verified hardware bits 29+25 are NOT cleared by this write, but the write does
+/// clear bits[15:0] and is correct on other platforms where the sticky bits reset.
+///
+/// **BB+0x64 must NOT be used**: `gptrLLEReg+0x64` is event-driven and only
 /// decrements during active hardware connection events (`RF_Tx` path, asm line 72938).
-/// It never decrements for standalone DTM/ADV TX bursts — use this function instead.
+/// It never decrements for standalone DTM/ADV TX bursts — this function is correct.
 ///
 /// # Parameters
 ///
-/// * `timeout_loops` — number of spin_loop iterations to wait for the fire signal
-///   before declaring timeout. Use `10_000` for typical ADV/DTM use.
-/// * `settle_loops` — number of spin_loop iterations to wait after the fire signal
-///   is detected, to allow the over-the-air packet to complete. At 144 MHz,
-///   ~50_000 ≈ 350 µs (sufficient for a 19-byte ADV_NONCONN_IND @ 1 Mbps).
+/// * `timeout_loops` — spin_loop iterations to wait for fire detection (first TX
+///   only; subsequent TXs detect immediately). Use `10_000` for ADV/DTM.
+/// * `settle_loops` — spin_loop iterations after detection for on-air completion.
+///   At 144 MHz, `50_000` ≈ 350 µs (covers 19-byte ADV_NONCONN_IND @ 1 Mbps:
+///   90 µs pre-delay + 240 µs on-air = 330 µs).
 ///
 /// # Safety
 ///
-/// Must be called after `ble_phy_init()` and after issuing a GO strobe to the
-/// BLE link-layer engine. Caller is responsible for TX mode setup.
+/// Must be called after `ble_phy_init()` and after the GO strobe has been written
+/// to the BLE link-layer engine. Caller is responsible for TX mode setup.
 pub unsafe fn ble_tx_wait_done(timeout_loops: u32, settle_loops: u32) -> bool {
     let irq_reg = (GPTRLLE_BASE + 0x08) as *const u32;
     for _ in 0..timeout_loops {

--- a/src/ble/mod.rs
+++ b/src/ble/mod.rs
@@ -88,17 +88,47 @@ const OSC_HSE_CAL_CTRL: *mut u32 = 0x4002_202C as *mut u32;
 const RCC_AHBPCENR: *mut u32 = 0x4002_1014 as *mut u32;
 const RCC_AHBPCENR_CRC_EN: u32 = 1 << 6;
 
+/// RCC CTLR register address.
+/// bit16=HSEON, bit17=HSERDY (32 MHz external crystal).
+const RCC_CTLR: *mut u32 = 0x4002_1000 as *mut u32;
+
 /// Initialize the BLE PHY hardware layer.
 ///
-/// Must be called after the system clock (HSE 32 MHz) is running and stable.
-/// Enables CRC clock and NVIC interrupts BB/LLE.
+/// Enables the HSE 32 MHz external crystal (required by the BLE RF frontend as its
+/// reference oscillator), then runs rfend/bb/lle init and RF calibration.
+///
+/// **Clock note**: the CH32V208WBU6 BLE RF frontend requires HSE (the 32 MHz external
+/// crystal) to be oscillating regardless of the system clock source. If `hal::init` was
+/// called with `Default::default()` (which leaves HSEON=0), this function enables HSE
+/// before proceeding.  The system CPU clock is left unchanged — only HSE is enabled.
 ///
 /// # Safety
 ///
 /// Must be called exactly once at startup, before any BLE operation.
 /// Interrupts BB (63) and LLE (64) must have handlers registered before calling.
 pub unsafe fn ble_phy_init() {
-    // Configure 32 MHz crystal oscillator calibration.
+    // ── Step 0: ensure HSE (32 MHz external crystal) is running ──────────────
+    // The BLE RF frontend uses HSE as its reference oscillator.
+    // WCH official SDK relies on SystemInit() to enable HSE before BLE init;
+    // our Rust hal::init(Default::default()) leaves HSEON=0 (HSI only).
+    // We enable HSE here if not already running.
+    let ctlr = core::ptr::read_volatile(RCC_CTLR);
+    if ctlr & (1 << 17) == 0 {
+        // HSERDY=0: enable HSE and wait up to ~50k iterations for HSERDY.
+        core::ptr::write_volatile(RCC_CTLR, ctlr | (1 << 16)); // set HSEON
+        let mut i = 0u32;
+        while core::ptr::read_volatile(RCC_CTLR) & (1 << 17) == 0 {
+            i += 1;
+            if i > 50_000 {
+                // Crystal did not start — proceed anyway; RF will not function.
+                break;
+            }
+            core::hint::spin_loop();
+        }
+    }
+
+    // ── Step 1: 32 MHz crystal oscillator calibration ────────────────────────
+    // Configure 32 MHz crystal load capacitance and drive current.
     // From WCHBLE_Init (MCU.c): clear bits[30:28], set to 0x3 << 28, set 3 << 24.
     let osc = core::ptr::read_volatile(OSC_HSE_CAL_CTRL);
     let osc = (osc & !(0x07 << 28)) | (0x03 << 28);

--- a/src/ble/mod.rs
+++ b/src/ble/mod.rs
@@ -16,6 +16,9 @@
 pub mod bb;
 pub mod lle;
 pub mod rfend;
+pub mod regint;
+
+pub use regint::ble_reg_init;
 
 use bb::bb_dev_init;
 use lle::lle_dev_init;

--- a/src/ble/mod.rs
+++ b/src/ble/mod.rs
@@ -14,6 +14,7 @@
 // Verification (Phase 1 milestone): DTM single-tone TX at 2402/2426/2480 MHz
 // visible on spectrum analyzer or SDR confirms RF path is operational.
 
+pub mod adv;
 pub mod bb;
 pub mod lle;
 pub mod rfend;

--- a/src/ble/mod.rs
+++ b/src/ble/mod.rs
@@ -9,6 +9,7 @@
 //   4. lle_dev_init()    — Link layer engine timing + IRQ setup
 //   5. Enable CRC peripheral clock (RCC AHB)
 //   6. Enable NVIC interrupts: BB (IRQn 63), LLE (IRQn 64)
+//   7. ble_reg_init()    — RF calibration (CO/GA tables; tail-called from BLE_IPCoreInit)
 //
 // Verification (Phase 1 milestone): DTM single-tone TX at 2402/2426/2480 MHz
 // visible on spectrum analyzer or SDR confirms RF path is operational.
@@ -65,4 +66,7 @@ pub unsafe fn ble_phy_init() {
     // Enabling IRQs without registered handlers causes unhandled exception faults.
     // Applications that use interrupt-driven BLE (TMOS/BLE stack) must enable
     // them separately after installing BB_IRQHandler / LLE_IRQHandler.
+
+    // RF calibration: CO/GA lookup tables (mirrors BLE_RegInit tail-call in BLE_IPCoreInit).
+    ble_reg_init();
 }

--- a/src/ble/mod.rs
+++ b/src/ble/mod.rs
@@ -1,0 +1,72 @@
+// BLE PHY initialization for CH32V208.
+//
+// Phase 1: Hardware init sequence to bring RFEND/BB/LLE into operational state.
+//
+// Init order (from WCHBLE_Init → BLE_IPCoreInit in libwchble.a V1.40):
+//   1. OSC HSE calibration (32 MHz crystal, done by caller before BLE init)
+//   2. rfend_dev_init()  — RF frontend reset + analog config
+//   3. bb_dev_init()     — Baseband processor config
+//   4. lle_dev_init()    — Link layer engine timing + IRQ setup
+//   5. Enable CRC peripheral clock (RCC AHB)
+//   6. Enable NVIC interrupts: BB (IRQn 63), LLE (IRQn 64)
+//
+// Verification (Phase 1 milestone): DTM single-tone TX at 2402/2426/2480 MHz
+// visible on spectrum analyzer or SDR confirms RF path is operational.
+
+pub mod bb;
+pub mod lle;
+pub mod rfend;
+
+use bb::bb_dev_init;
+use lle::lle_dev_init;
+use rfend::rfend_dev_init;
+
+/// OSC base address: AHBPERIPH_BASE (0x40020000) + 0x202C = 0x4002202C
+/// Contains HSE_CAL_CTRL at offset +0x00.
+const OSC_HSE_CAL_CTRL: *mut u32 = 0x4002_202C as *mut u32;
+
+/// RCC AHB peripheral enable register (AHBPCENR).
+/// CH32V208: CRC clock bit is bit 6.
+const RCC_AHBPCENR: *mut u32 = 0x4002_1014 as *mut u32;
+const RCC_AHBPCENR_CRC_EN: u32 = 1 << 6;
+
+/// Initialize the BLE PHY hardware layer.
+///
+/// Must be called after the system clock (HSE 32 MHz) is running and stable.
+/// Enables CRC clock and NVIC interrupts BB/LLE.
+///
+/// # Safety
+///
+/// Must be called exactly once at startup, before any BLE operation.
+/// Interrupts BB (63) and LLE (64) must have handlers registered before calling.
+pub unsafe fn ble_phy_init() {
+    // Configure 32 MHz crystal oscillator calibration.
+    // From WCHBLE_Init (MCU.c): clear bits[30:28], set to 0x3 << 28, set 3 << 24.
+    let osc = core::ptr::read_volatile(OSC_HSE_CAL_CTRL);
+    let osc = (osc & !(0x07 << 28)) | (0x03 << 28);
+    let osc = osc | (3 << 24);
+    core::ptr::write_volatile(OSC_HSE_CAL_CTRL, osc);
+
+    // RF frontend: reset then configure analog front end.
+    rfend_dev_init();
+
+    // Baseband processor: configure mode and timing.
+    bb_dev_init(bb::BB_RF_FLAG_1M);
+
+    // Link layer engine: configure timing params and IRQ mask.
+    lle_dev_init();
+
+    // Enable CRC peripheral clock (required by BLE stack).
+    let ahb = core::ptr::read_volatile(RCC_AHBPCENR);
+    core::ptr::write_volatile(RCC_AHBPCENR, ahb | RCC_AHBPCENR_CRC_EN);
+
+    // Enable BB and LLE interrupts at the NVIC level.
+    // CH32V208: BB=IRQn 63, LLE=IRQn 64.
+    // PFIC IENR registers: IENR1 covers IRQ32-63, IENR2 covers IRQ64-95.
+    const PFIC_IENR1: *mut u32 = 0xE000_E100 as *mut u32; // IRQ 32-63
+    const PFIC_IENR2: *mut u32 = 0xE000_E104 as *mut u32; // IRQ 64-95
+    // BB IRQn 63 → bit 31 of IENR1
+    core::ptr::write_volatile(PFIC_IENR1, 1 << 31);
+    // LLE IRQn 64 → bit 0 of IENR2
+    core::ptr::write_volatile(PFIC_IENR2, 1 << 0);
+}

--- a/src/ble/mod.rs
+++ b/src/ble/mod.rs
@@ -26,6 +26,50 @@ use bb::bb_dev_init;
 use lle::lle_dev_init;
 use rfend::rfend_dev_init;
 
+// ── Shared BLE TX completion primitive ──────────────────────────────────────
+
+/// gptrLLEReg base address — IRQ status at offset +0x08.
+const GPTRLLE_BASE: usize = 0x40024200;
+
+/// Wait for a BLE TX burst to fire and settle, using the DTM-style completion signal.
+///
+/// **Completion signal**: `BB+0x08` bits 29+25 (`0x2200_0000`) are set by the GO
+/// strobe when a TX burst fires. These bits are not W1C-clearable (sticky), so
+/// they only transition 0 → non-zero once per power cycle (at the first TX after
+/// reset). After the first TX they are permanently set; callers that need per-burst
+/// fire detection must clear `BB+0x08` with a full 32-bit W1C write before each GO.
+///
+/// **BB+0x64 is NOT the indicator**: `gptrLLEReg+0x64` is event-driven and only
+/// decrements during active hardware connection events (`RF_Tx` path, asm line 72938).
+/// It never decrements for standalone DTM/ADV TX bursts — use this function instead.
+///
+/// # Parameters
+///
+/// * `timeout_loops` — number of spin_loop iterations to wait for the fire signal
+///   before declaring timeout. Use `10_000` for typical ADV/DTM use.
+/// * `settle_loops` — number of spin_loop iterations to wait after the fire signal
+///   is detected, to allow the over-the-air packet to complete. At 144 MHz,
+///   ~50_000 ≈ 350 µs (sufficient for a 19-byte ADV_NONCONN_IND @ 1 Mbps).
+///
+/// # Safety
+///
+/// Must be called after `ble_phy_init()` and after issuing a GO strobe to the
+/// BLE link-layer engine. Caller is responsible for TX mode setup.
+pub unsafe fn ble_tx_wait_done(timeout_loops: u32, settle_loops: u32) -> bool {
+    let irq_reg = (GPTRLLE_BASE + 0x08) as *const u32;
+    for _ in 0..timeout_loops {
+        if core::ptr::read_volatile(irq_reg) & 0x2200_0000 != 0 {
+            // TX fired. Spin for packet-on-air completion before returning.
+            for _ in 0..settle_loops {
+                core::hint::spin_loop();
+            }
+            return true;
+        }
+        core::hint::spin_loop();
+    }
+    false
+}
+
 /// OSC base address: AHBPERIPH_BASE (0x40020000) + 0x202C = 0x4002202C
 /// Contains HSE_CAL_CTRL at offset +0x00.
 const OSC_HSE_CAL_CTRL: *mut u32 = 0x4002_202C as *mut u32;

--- a/src/ble/regint.rs
+++ b/src/ble/regint.rs
@@ -188,14 +188,19 @@ unsafe fn rfend_tx_ctune() {
             }
             v &= !(0xF << 16); // nibble4 = 0 (separator)
             for n in 0..3usize {
-                let nib = ((delta_ga2 * (n as i32 + 1) / delta_low) & 0xF) as u32;
+                let raw = delta_ga2 * (n as i32 + 1) / delta_low;
+                // dtm.elf has no clamping here; hardware expects GA2 nibbles in [0..7].
+                debug_assert!((0..=7).contains(&raw), "GA2 nibble out of range: {}", raw);
+                let nib = (raw & 0xF) as u32;
                 v = (v & !(0xF << ((n + 5) * 4))) | (nib << ((n + 5) * 4));
             }
             w(0xCC, v);
 
             let mut v = r(0xD0);
             for n in 0..7usize {
-                let nib = ((delta_ga2 * (n as i32 + 4) / delta_low) & 0xF) as u32;
+                let raw = delta_ga2 * (n as i32 + 4) / delta_low;
+                debug_assert!((0..=7).contains(&raw), "GA2 nibble out of range: {}", raw);
+                let nib = (raw & 0xF) as u32;
                 v = (v & !(0xF << (n * 4))) | (nib << (n * 4));
             }
             v &= !(0xF << 28); // nibble7 = 0

--- a/src/ble/regint.rs
+++ b/src/ble/regint.rs
@@ -146,49 +146,61 @@ unsafe fn rfend_tx_ctune() {
     let prev_c8 = r(0xC8);
     w(0xC8, (prev_c8 & !0xFF) | co2_ch40 | (co2_ch41 << 4));
 
-    // GA table segment 1 (0xC8 nibbles 2-7, 0xCC nibbles 0-3):
-    //   GA1[n] = (delta_ga * (10-n) / delta_high | 8) & 0xF  for n=0..9
-    //   Divisor = delta_high; multipliers 10→1 descending; |8 minimum bias.
-    // GA table separator: 0xCC nibble4 = 0 (explicitly confirmed from assembly).
-    // GA table segment 2 (0xCC nibbles 5-7, 0xD0 nibbles 0-6):
-    //   GA2[n] = (delta_ga2 * (n+1) / delta_low) & 0xF  for n=0..9
-    //   Divisor = delta_low; multipliers 1→10 ascending; no |8 bias.
-    //   0xD0 nibble7 = 0 (confirmed from assembly).
+    // GA calibration tables (skipped if either CO delta is zero — degenerate hardware).
+    // GA1 (0xC8 nibbles 2-7, 0xCC nibbles 0-3): GA1[n] = (delta_ga*(10-n)/delta_high|8)&0xF
+    //   Divisor = delta_high; mults 10→1 descending; |8 minimum bias.
+    // GA2 (0xCC nibbles 5-7, 0xD0 nibbles 0-6):  GA2[n] = (delta_ga2*(n+1)/delta_low)&0xF
+    //   Divisor = delta_low; mults 1→10 ascending; no |8 bias.
+    //   Negative delta_ga2 is valid: RISC-V idiv truncates toward zero, & 0xF gives
+    //   4-bit two's-complement, which hardware interprets as a signed gain offset.
+    //   This matches dtm.elf exactly — `lbu` loads nGA as [0..127], `sub` may go negative,
+    //   then `and s1, s1, 15` is applied with no sign correction (confirmed from asm f73e-f748).
+    // 0xCC nibble4 = 0 (separator, confirmed from asm).  0xD0 nibble7 = 0 (confirmed).
     let delta_ga = nga2440 as i32 - nga2480 as i32;
     let delta_ga2 = nga2401 as i32 - nga2440 as i32;
 
-    // 0xC8 nibbles 2-7: GA1[0..5], preserving CO2 overflow in nibbles 0-1.
-    {
-        let mut v = r(0xC8);
-        for n in 0..6usize {
-            let nib = ((delta_ga * (10 - n as i32) / delta_high | 8) & 0xF) as u32;
-            let pos = (n + 2) * 4;
-            v = (v & !(0xF << pos)) | (nib << pos);
+    if delta_high == 0 || delta_low == 0 {
+        // Degenerate measurement (cold start, hardware anomaly): CO tables already written.
+        // GA tables require a non-zero CO delta for normalization; skip to avoid divide-by-zero.
+        #[cfg(feature = "defmt")]
+        defmt::warn!(
+            "rfend_tx_ctune: skipping GA cal (delta_high={} delta_low={})",
+            delta_high, delta_low
+        );
+    } else {
+        // 0xC8 nibbles 2-7: GA1[0..5], preserving CO2 overflow in nibbles 0-1.
+        {
+            let mut v = r(0xC8);
+            for n in 0..6usize {
+                let nib = ((delta_ga * (10 - n as i32) / delta_high | 8) & 0xF) as u32;
+                let pos = (n + 2) * 4;
+                v = (v & !(0xF << pos)) | (nib << pos);
+            }
+            w(0xC8, v);
         }
-        w(0xC8, v);
-    }
-    // 0xCC: GA1[6..9] at nibbles 0-3, separator at nibble4, GA2[0..2] at nibbles 5-7.
-    // 0xD0: GA2[3..9] at nibbles 0-6, nibble7 cleared.
-    {
-        let mut v = r(0xCC);
-        for n in 0..4usize {
-            let nib = ((delta_ga * (4 - n as i32) / delta_high | 8) & 0xF) as u32;
-            v = (v & !(0xF << (n * 4))) | (nib << (n * 4));
-        }
-        v &= !(0xF << 16); // nibble4 = 0 (separator)
-        for n in 0..3usize {
-            let nib = ((delta_ga2 * (n as i32 + 1) / delta_low) & 0xF) as u32;
-            v = (v & !(0xF << ((n + 5) * 4))) | (nib << ((n + 5) * 4));
-        }
-        w(0xCC, v);
+        // 0xCC: GA1[6..9] at nibbles 0-3, separator at nibble4, GA2[0..2] at nibbles 5-7.
+        // 0xD0: GA2[3..9] at nibbles 0-6, nibble7 cleared.
+        {
+            let mut v = r(0xCC);
+            for n in 0..4usize {
+                let nib = ((delta_ga * (4 - n as i32) / delta_high | 8) & 0xF) as u32;
+                v = (v & !(0xF << (n * 4))) | (nib << (n * 4));
+            }
+            v &= !(0xF << 16); // nibble4 = 0 (separator)
+            for n in 0..3usize {
+                let nib = ((delta_ga2 * (n as i32 + 1) / delta_low) & 0xF) as u32;
+                v = (v & !(0xF << ((n + 5) * 4))) | (nib << ((n + 5) * 4));
+            }
+            w(0xCC, v);
 
-        let mut v = r(0xD0);
-        for n in 0..7usize {
-            let nib = ((delta_ga2 * (n as i32 + 4) / delta_low) & 0xF) as u32;
-            v = (v & !(0xF << (n * 4))) | (nib << (n * 4));
+            let mut v = r(0xD0);
+            for n in 0..7usize {
+                let nib = ((delta_ga2 * (n as i32 + 4) / delta_low) & 0xF) as u32;
+                v = (v & !(0xF << (n * 4))) | (nib << (n * 4));
+            }
+            v &= !(0xF << 28); // nibble7 = 0
+            w(0xD0, v);
         }
-        v &= !(0xF << 28); // nibble7 = 0
-        w(0xD0, v);
     }
 
     // Teardown: clear calibration mode, switch to operational state.

--- a/src/ble/regint.rs
+++ b/src/ble/regint.rs
@@ -6,25 +6,30 @@
 //   3. RFEND_RXFilter — RX filter self-calibration with hardware poll
 //   4. RFEND_RXAdc    — RX ADC reference configuration
 //
-// All calibration functions use gptrRFENDReg (0x40025000) as the RFEND base.
-// This is DISTINCT from the RFEND_DevInit base at 0x40024300 (gptrAESReg).
+// Register bases (WCH uses two distinct RFEND address regions):
+//   RFEND_BASE    (rfend.rs)  = 0x40024300  — gptrAESReg, used by RFEND_DevInit only
+//   RFEND_CAL_BASE (this file) = 0x40025000  — gptrRFENDReg, PA bias / PLL / cal tables
+//
+// The 0x40025000 block was confirmed by dumping memory after running official dtm.elf:
+//   wlink dump 0x40025000+0xA0..0xC8 → CO1 table word0=0x45555556 (ch0=6,ch7=4),
+//   CO2 table word0=0x11100000 (ch0=0,ch5=1) — matches RFEND_TXCtune algorithm ✓.
 //
 // Register intent map (from disassembly of libwchble.a V1.40, confirmed):
-//   RFEND+0x04  bits: bit0=TX_tune_trigger, bit4=TX_cal_mode, bit8=TXF_enable,
-//                     bit12=RX_filter_mode, bit16=RX_ADC_config
-//   RFEND+0x08  bits: bit16=RX_ADC_path, bit17=TX_cal_path, bit21=RX_filter_path
-//   RFEND+0x0C  bits: bit4=RX_filter_strobe, bit8=ADC_ref_strobe
-//   RFEND+0x28  bits: bit12=TX_tune_mode_final (set after calibration completes)
-//   RFEND+0x2C  bits: bit4=post_cal_enable
-//   RFEND+0x38  bits[15:8]=freq_code, bits[5:0]=nCO2440, bits[30:24]=nGA2440
-//   RFEND+0x50  bits: bit16=RX_filter_valid, bits[4:0]=RX_filter_result
-//   RFEND+0x58  bits: bit16=RX_ADC_ref_enable
-//   RFEND+0x90  bits: bits[5:0]=CO_result, bit25=tune_done, bit26=tune_active
-//   RFEND+0x94  bits[16:10]: GA_result (7 bits)
-//   RFEND+0x9C  bits: bit8=RX_filter_done, bits[4:0]=RX_filter_result
-//   RFEND+0xA0..0xB0: CO calibration table 1 (nibble-packed, 40 channels, ch0→ch39)
-//   RFEND+0xB4..0xC4: CO calibration table 2 (nibble-packed, 40 channels, ch0→ch39)
-//   RFEND+0xC8..0xD0: GA calibration + CO overflow (partially reversed, see TODO)
+//   +0x04  bits: bit0=TX_tune_trigger, bit4=TX_cal_mode, bit8=TXF_enable,
+//                bit12=RX_filter_mode, bit16=RX_ADC_config
+//   +0x08  bits: bit16=RX_ADC_path, bit17=TX_cal_path, bit21=RX_filter_path
+//   +0x0C  bits: bit4=RX_filter_strobe, bit8=ADC_ref_strobe
+//   +0x28  bits: bit12=TX_tune_mode_final (set after calibration completes)
+//   +0x2C  bits: bit4=post_cal_enable
+//   +0x38  bits[15:8]=freq_code, bits[5:0]=nCO2440, bits[30:24]=nGA2440
+//   +0x50  bits: bit16=RX_filter_valid, bits[4:0]=RX_filter_result
+//   +0x58  bits: bit16=RX_ADC_ref_enable
+//   +0x90  bits: bits[5:0]=CO_result, bit25=tune_done, bit26=tune_active
+//   +0x94  bits[16:10]: GA_result (7 bits)
+//   +0x9C  bits: bit8=RX_filter_done, bits[4:0]=RX_filter_result
+//   +0xA0..0xB0: CO calibration table 1 (nibble-packed, 40 channels, ch0→ch39)
+//   +0xB4..0xC4: CO calibration table 2 (nibble-packed, 40 channels, ch0→ch39)
+//   +0xC8..0xD0: GA calibration + CO2 overflow
 //
 // Sources: static disassembly of dtm.elf (WCH BLE SDK V1.40), live register dump.
 
@@ -32,23 +37,25 @@ use core::arch::asm;
 use core::ptr::{read_volatile, write_volatile};
 
 // gptrRFENDReg: PA bias, PLL, channel lock, calibration tables.
-const RFEND_BASE: usize = 0x40025000;
+// Distinct from RFEND_BASE in rfend.rs (0x40024300 = gptrAESReg used by RFEND_DevInit).
+const RFEND_CAL_BASE: usize = 0x40025000;
 // gptrLLEReg: provides LLE+0x64 countdown register for calibration timeouts.
 const LLE_BASE: usize = 0x40024200;
 
-// Magic cookie: if ftuneFlag matches this value, RFEND_TXCtune skips re-measurement
-// and reuses cached nCO/nGA values from the previous calibration run.
-// Writing 0 to ftuneFlag forces a fresh calibration on next call.
-// WCH stores ftuneFlag at a fixed RAM address; we always run fresh.
+// Frequency selection codes written to RFEND_CAL_BASE+0x38 bits[15:8].
+// Confirmed from BB_DevInit / RF_DevSetChannel disassembly.
+const FREQ_CODE_2401: u32 = 0xBF00; // one step below BLE ch0 (2402 MHz)
+const FREQ_CODE_2480: u32 = 0xE700; // BLE ch39
+const FREQ_CODE_2440: u32 = 0xD300; // BLE ch19, band midpoint
 
 #[inline(always)]
 unsafe fn r(off: usize) -> u32 {
-    read_volatile((RFEND_BASE + off) as *const u32)
+    read_volatile((RFEND_CAL_BASE + off) as *const u32)
 }
 
 #[inline(always)]
 unsafe fn w(off: usize, val: u32) {
-    write_volatile((RFEND_BASE + off) as *mut u32, val);
+    write_volatile((RFEND_CAL_BASE + off) as *mut u32, val);
 }
 
 #[inline(always)]
@@ -72,59 +79,57 @@ pub unsafe fn ble_reg_init() {
 
 /// RFEND_TXCtune: TX carrier oscillator + gain calibration.
 ///
-/// Measures CO (carrier offset, bits[5:0] of RFEND+0x90) and GA (gain adjust,
-/// bits[16:10] of RFEND+0x94) at 3 reference frequencies (2401, 2480, 2440 MHz),
-/// then linearly interpolates two 40-channel nibble-packed lookup tables.
+/// Measures CO (carrier offset, RFEND+0x90 bits[5:0]) and GA (gain adjust,
+/// RFEND+0x94 bits[16:10]) at 3 reference frequencies (2401, 2480, 2440 MHz),
+/// then linearly interpolates two CO tables and two GA segments into
+/// nibble-packed lookup tables spanning RFEND+0xA0..0xD0.
 ///
-/// After calibration, RFEND+0x38 stores nCO2440 in bits[5:0] and nGA2440 in
-/// bits[30:24] as the default channel configuration.
+/// Delta values (nCOxxx, nGAxxx) are signed 8-bit hardware measurements.
+/// In practice delta_low (CO1 span) ≈ 6, delta_high (CO2 span) ≈ 7 per
+/// live dump. Both must be in [-8..+7] for the 4-bit nibble encoding to
+/// hold without overflow.
+///
+/// After calibration, RFEND+0x38 bits[5:0] = nCO2440, bits[30:24] = nGA2440.
 unsafe fn rfend_tx_ctune() {
     // Setup: clear calibration-mode bits, enable TX cal path.
-    // RFEND+0x04 clear bit8 (TXF enable off during CO tune)
-    rmw(0x04, 1 << 8, 0);
-    // RFEND+0x28 clear bit12 (TX tune mode not yet final)
-    rmw(0x28, 1 << 12, 0);
-    // RFEND+0x2C clear bits[3:0]
-    rmw(0x2C, 0xF, 0);
-    // RFEND+0x08 set bit17 (TX calibration path enable)
-    rmw(0x08, 0, 1 << 17);
-    // RFEND+0x04 set bit4 (TX calibration mode)
-    rmw(0x04, 0, 1 << 4);
+    rmw(0x04, 1 << 8, 0);  // clear bit8 (TXF enable off during CO tune)
+    rmw(0x28, 1 << 12, 0); // clear bit12 (TX tune mode not yet final)
+    rmw(0x2C, 0xF, 0);     // clear bits[3:0]
+    rmw(0x08, 0, 1 << 17); // set bit17 (TX calibration path enable)
+    rmw(0x04, 0, 1 << 4);  // set bit4 (TX calibration mode)
 
-    // Measure CO and GA at 3 reference frequencies.
-    // Freq codes for RFEND+0x38 bits[15:8]: confirmed from BB_DevInit/RF_DevSetChannel.
-    //   0xBF = 191 → 2401 MHz  (one step below BLE ch0 at 2402 MHz)
-    //   0xE7 = 231 → 2480 MHz  (= BLE ch39)
-    //   0xD3 = 211 → 2440 MHz  (≈ BLE ch19, midpoint)
-    let (nco2401, nga2401) = tx_tune_measure(0xBF00);
-    let (nco2480, nga2480) = tx_tune_measure(0xE700);
-    let (nco2440, nga2440) = tx_tune_measure(0xD300);
+    let (nco2401, nga2401) = tx_tune_measure(FREQ_CODE_2401);
+    let (nco2480, nga2480) = tx_tune_measure(FREQ_CODE_2480);
+    let (nco2440, nga2440) = tx_tune_measure(FREQ_CODE_2440);
 
     // CO table 1 (RFEND+0xA0..0xB0, 5 words, 40 nibbles for ch0..ch39).
-    // Linear interpolation anchored at nCO2401 (ch0) and nCO2440 (ch19):
-    //   CO1[0]  = (nco2401 - nco2440) & 0xF          (raw delta, ch0)
-    //   CO1[ch] = (nco2401 - nco2440) * (39-ch) / 39  for ch = 1..39
-    // Confirmed: live dump CO1[0]=6, CO1[39]=0, monotone decreasing.
+    // CO1[ch] = delta_low * (39-ch) / 39  for ch=0..39
+    // where delta_low = nCO2401 - nCO2440 (monotone decreasing: ch0=delta_low → ch39=0).
+    // Live dump: delta_low=6, CO1[0]=6, CO1[39]=0 ✓
     let delta_low = nco2401 as i32 - nco2440 as i32;
+    debug_assert!(
+        (-8..=7).contains(&delta_low),
+        "delta_low={} out of 4-bit signed range; CO1 nibbles will wrap", delta_low
+    );
     for word in 0..5usize {
         let mut word_val = 0u32;
         for i in 0..8usize {
             let ch = word * 8 + i;
-            let nibble = if ch == 0 {
-                (delta_low & 0xF) as u32
-            } else {
-                ((delta_low * (39 - ch as i32) / 39) & 0xF) as u32
-            };
+            let nibble = ((delta_low * (39 - ch as i32) / 39) & 0xF) as u32;
             word_val |= nibble << (i * 4);
         }
         w(0xA0 + word * 4, word_val);
     }
 
     // CO table 2 (RFEND+0xB4..0xC4, 5 words, 40 nibbles for ch0..ch39).
-    // Anchored at nCO2440 and nCO2480:
-    //   CO2[ch] = (nco2440 - nco2480) * (ch+1) / 40  for ch = 0..39
-    // Confirmed: live dump CO2[0]=0, CO2[39]=7, monotone increasing.
+    // CO2[ch] = delta_high * (ch+1) / 40  for ch=0..39
+    // where delta_high = nCO2440 - nCO2480 (monotone increasing: ch0≈0 → ch39=delta_high).
+    // Live dump: delta_high=7, CO2[0]=0, CO2[39]=7 ✓
     let delta_high = nco2440 as i32 - nco2480 as i32;
+    debug_assert!(
+        (-8..=7).contains(&delta_high),
+        "delta_high={} out of 4-bit signed range; CO2 nibbles will wrap", delta_high
+    );
     for word in 0..5usize {
         let mut word_val = 0u32;
         for i in 0..8usize {
@@ -135,54 +140,54 @@ unsafe fn rfend_tx_ctune() {
         w(0xB4 + word * 4, word_val);
     }
 
-    // CO2 overflow: 2 extra entries at RFEND+0xC8 nibbles 0-1 (ch40, ch41).
-    // The hardware reads up to ch41 for guard-band / out-of-band channels.
+    // CO2 overflow at RFEND+0xC8 nibbles 0-1 (ch40, ch41 for guard-band use).
     let co2_ch40 = ((delta_high * 41 / 40) & 0xF) as u32;
     let co2_ch41 = ((delta_high * 42 / 40) & 0xF) as u32;
     let prev_c8 = r(0xC8);
     w(0xC8, (prev_c8 & !0xFF) | co2_ch40 | (co2_ch41 << 4));
 
     // GA table segment 1 (0xC8 nibbles 2-7, 0xCC nibbles 0-3):
-    // Multipliers 10→1 descending, divisor=delta_high, |8 minimum bias.
-    // GA1[n] = (delta_ga * (10-n) / delta_high | 8) & 0xF, n=0..9
+    //   GA1[n] = (delta_ga * (10-n) / delta_high | 8) & 0xF  for n=0..9
+    //   Divisor = delta_high; multipliers 10→1 descending; |8 minimum bias.
+    // GA table separator: 0xCC nibble4 = 0 (explicitly confirmed from assembly).
+    // GA table segment 2 (0xCC nibbles 5-7, 0xD0 nibbles 0-6):
+    //   GA2[n] = (delta_ga2 * (n+1) / delta_low) & 0xF  for n=0..9
+    //   Divisor = delta_low; multipliers 1→10 ascending; no |8 bias.
+    //   0xD0 nibble7 = 0 (confirmed from assembly).
     let delta_ga = nga2440 as i32 - nga2480 as i32;
+    let delta_ga2 = nga2401 as i32 - nga2440 as i32;
+
+    // 0xC8 nibbles 2-7: GA1[0..5], preserving CO2 overflow in nibbles 0-1.
     {
-        // 0xC8 nibbles 2-7 (n=0..5, mult=10..5): preserve CO2 overflow in nibbles 0-1.
         let mut v = r(0xC8);
         for n in 0..6usize {
-            let mult = (10 - n) as i32;
-            let nib = ((delta_ga * mult / delta_high | 8) & 0xF) as u32;
+            let nib = ((delta_ga * (10 - n as i32) / delta_high | 8) & 0xF) as u32;
             let pos = (n + 2) * 4;
             v = (v & !(0xF << pos)) | (nib << pos);
         }
         w(0xC8, v);
     }
+    // 0xCC: GA1[6..9] at nibbles 0-3, separator at nibble4, GA2[0..2] at nibbles 5-7.
+    // 0xD0: GA2[3..9] at nibbles 0-6, nibble7 cleared.
     {
-        // 0xCC: nibbles 0-3 (GA1 n=6..9, mult=4..1), nibble4=0, nibbles 5-7 (GA2 n=0..2, mult=1..3).
-        // GA segment 2: delta_ga2 = nGA2401-nGA2440, divisor=delta_low (=nCO2401-nCO2440).
-        // GA2[n] = (delta_ga2 * (n+1) / delta_low) & 0xF  — no |8 bias.
-        let delta_ga2 = nga2401 as i32 - nga2440 as i32;
         let mut v = r(0xCC);
         for n in 0..4usize {
-            let mult = (4 - n) as i32;
-            let nib = ((delta_ga * mult / delta_high | 8) & 0xF) as u32;
+            let nib = ((delta_ga * (4 - n as i32) / delta_high | 8) & 0xF) as u32;
             v = (v & !(0xF << (n * 4))) | (nib << (n * 4));
         }
-        v &= !(0xF << 16); // nibble 4 = 0 (separator between the two GA segments)
+        v &= !(0xF << 16); // nibble4 = 0 (separator)
         for n in 0..3usize {
-            let mult = (n + 1) as i32;
-            let nib = ((delta_ga2 * mult / delta_low) & 0xF) as u32;
+            let nib = ((delta_ga2 * (n as i32 + 1) / delta_low) & 0xF) as u32;
             v = (v & !(0xF << ((n + 5) * 4))) | (nib << ((n + 5) * 4));
         }
         w(0xCC, v);
-        // 0xD0 nibbles 0-6 (GA2 n=3..9, mult=4..10); nibble7 cleared to 0.
+
         let mut v = r(0xD0);
         for n in 0..7usize {
-            let mult = (n + 4) as i32;
-            let nib = ((delta_ga2 * mult / delta_low) & 0xF) as u32;
+            let nib = ((delta_ga2 * (n as i32 + 4) / delta_low) & 0xF) as u32;
             v = (v & !(0xF << (n * 4))) | (nib << (n * 4));
         }
-        v &= !(0xF << 28);
+        v &= !(0xF << 28); // nibble7 = 0
         w(0xD0, v);
     }
 
@@ -191,8 +196,8 @@ unsafe fn rfend_tx_ctune() {
     rmw(0x28, 0, 1 << 12);       // set bit12 (TX_tune_mode_final)
     rmw(0x2C, 0, 1 << 4);        // set bit4 (post_cal_enable)
 
-    // Store calibration anchors: nCO2440 in RFEND+0x38 bits[5:0], nGA2440 in bits[30:24].
-    // Hardware reads these on every TX burst for default channel compensation.
+    // Store calibration anchors: nCO2440 in bits[5:0], nGA2440 in bits[30:24].
+    // Hardware reads RFEND+0x38 on every TX burst for default channel compensation.
     let v = r(0x38);
     let v = (v & !0x3F) | (nco2440 as u32 & 0x3F);
     let v = (v & 0x80FF_FFFF) | ((nga2440 as u32 & 0x7F) << 24);
@@ -201,40 +206,45 @@ unsafe fn rfend_tx_ctune() {
 
 /// Perform one TX tune measurement at the given frequency code.
 ///
-/// `freq_code`: 16-bit value with bits[15:8] = frequency select code.
-///   0xBF00 = 2401 MHz, 0xE700 = 2480 MHz, 0xD300 = 2440 MHz.
+/// `freq_code`: value with bits[15:8] = frequency select code (e.g. `FREQ_CODE_2401`).
+/// Writes to RFEND+0x38 bits[15:8] (mask 0xFFFE_00FF clears bits[16:8]; bit16 is always 0).
 ///
-/// Returns (CO result [5:0], GA result [6:0]) after hardware tune completion.
+/// Returns (CO result bits[5:0], GA result bits[16:10]) after tune completion.
+/// On timeout the function returns whatever stale values are in the result registers.
 #[inline]
 unsafe fn tx_tune_measure(freq_code: u32) -> (u8, u8) {
-    // Clear bit0 (deassert previous trigger), set freq code, assert trigger.
-    rmw(0x04, 1, 0);
+    rmw(0x04, 1, 0); // deassert previous trigger
     let v = r(0x38);
-    w(0x38, (v & 0xFFFE_00FF) | freq_code); // bits[16:8] → freq code
-    rmw(0x04, 0, 1);
+    w(0x38, (v & 0xFFFE_00FF) | freq_code); // bits[15:8] ← freq code
+    rmw(0x04, 0, 1); // assert trigger
 
-    rfend_wait_tune();
+    if !rfend_wait_tune() {
+        #[cfg(feature = "defmt")]
+        defmt::warn!("rfend_wait_tune timeout (freq_code={:#06x})", freq_code);
+    }
 
-    let co = (r(0x90) & 0x3F) as u8;        // bits[5:0] of RFEND+0x90
-    let ga = ((r(0x94) >> 10) & 0x7F) as u8; // bits[16:10] of RFEND+0x94
+    let co = (r(0x90) & 0x3F) as u8;        // bits[5:0]
+    let ga = ((r(0x94) >> 10) & 0x7F) as u8; // bits[16:10]
     (co, ga)
 }
 
 /// Poll for TX tune completion using the LLE countdown timer as timeout.
 ///
-/// RFEND+0x90 bit26 = tune phase active; bit25 = tune done.
-/// LLE+0x64 is used as a software countdown written before polling.
+/// Polls RFEND+0x90 bit26 (active phase) + bit25 (done) in a single read per iteration.
+/// Assembly reads them separately (two lw instructions) but the combined check is
+/// functionally identical since we only proceed when both are set simultaneously.
+///
+/// Returns `true` if tune completed, `false` on timeout (LLE+0x64 reaches 0).
 #[inline]
-unsafe fn rfend_wait_tune() {
+unsafe fn rfend_wait_tune() -> bool {
     write_volatile((LLE_BASE + 0x64) as *mut u32, 6000);
     loop {
         let status = r(0x90);
         if status & (1 << 26) != 0 && status & (1 << 25) != 0 {
-            return; // active phase + done flag both set
+            return true;
         }
-        let countdown = read_volatile((LLE_BASE + 0x64) as *const u32);
-        if countdown == 0 {
-            return; // timeout
+        if read_volatile((LLE_BASE + 0x64) as *const u32) == 0 {
+            return false;
         }
     }
 }
@@ -250,39 +260,38 @@ unsafe fn rfend_tx_ftune() {
 /// RFEND_RXFilter: RX filter self-calibration.
 ///
 /// Hardware self-calibrates the RX filter, polls RFEND+0x9C bit8 for done,
-/// then stores the result bits[4:0] into RFEND+0x50 bits[4:0].
+/// then stores result bits[4:0] into RFEND+0x50 bits[4:0].
+/// On timeout the filter result register is read as-is (likely 0); RF will
+/// still operate but with uncompensated filter offset.
 /// From RFEND_RXFilter() at 0xead4 in dtm.elf.
 unsafe fn rfend_rx_filter() {
-    // Enable RX filter path and trigger calibration strobe.
-    rmw(0x50, 1 << 16, 0);          // RFEND+0x50 clear bit16 (RX_filter_valid)
-    rmw(0x08, 0, 1 << 21);          // RFEND+0x08 set bit21 (RX_filter_path enable)
-    rmw(0x0C, 0, 1 << 4);           // RFEND+0x0C set bit4 (strobe high)
-    rmw(0x0C, 1 << 4, 0);           // RFEND+0x0C clear bit4 (strobe low)
-    // 4-cycle delay for strobe settle.
+    rmw(0x50, 1 << 16, 0);          // clear bit16 (RX_filter_valid)
+    rmw(0x08, 0, 1 << 21);          // set bit21 (RX_filter_path enable)
+    rmw(0x0C, 0, 1 << 4);           // strobe high
+    rmw(0x0C, 1 << 4, 0);           // strobe low
     for _ in 0..4 {
-        unsafe { asm!("nop") };
+        unsafe { asm!("nop") };      // 4-cycle settle delay
     }
-    rmw(0x0C, 0, 1 << 4);           // RFEND+0x0C set bit4 (second strobe = actual trigger)
-    rmw(0x04, 0, 1 << 12);          // RFEND+0x04 set bit12 (RX_filter_mode)
+    rmw(0x0C, 0, 1 << 4);           // second strobe = actual calibration trigger
+    rmw(0x04, 0, 1 << 12);          // set bit12 (RX_filter_mode)
 
-    // Poll for done: RFEND+0x9C bit8, countdown from LLE+0x64 = 80.
     write_volatile((LLE_BASE + 0x64) as *mut u32, 80);
     loop {
         if r(0x9C) & (1 << 8) != 0 {
-            break; // calibration done
+            break;
         }
-        let countdown = read_volatile((LLE_BASE + 0x64) as *const u32);
-        if countdown == 0 {
-            break; // timeout
+        if read_volatile((LLE_BASE + 0x64) as *const u32) == 0 {
+            #[cfg(feature = "defmt")]
+            defmt::warn!("rfend_rx_filter timeout");
+            break;
         }
     }
 
-    // Store calibration result: RFEND+0x50 = (prev | bit16) with bits[4:0] = result.
     let result = r(0x9C) & 0x1F;
     let v = r(0x50);
     w(0x50, (v | (1 << 16)) & !0x1F | result);
 
-    rmw(0x08, 1 << 21, 0);          // RFEND+0x08 clear bit21 (disable RX filter path)
+    rmw(0x08, 1 << 21, 0);          // clear bit21 (disable RX filter path)
 }
 
 /// RFEND_RXAdc: configure RX ADC reference.
@@ -291,10 +300,10 @@ unsafe fn rfend_rx_filter() {
 /// the ADC reference configuration. No wait loop.
 /// From RFEND_RXAdc() at 0xeb68 in dtm.elf.
 unsafe fn rfend_rx_adc() {
-    rmw(0x58, 1 << 16, 0);          // RFEND+0x58 clear bit16 (RX_ADC_ref disable)
-    rmw(0x08, 0, 1 << 16);          // RFEND+0x08 set bit16 (RX_ADC path enable)
-    rmw(0x0C, 1 << 8, 0);           // RFEND+0x0C clear bit8 (ADC_ref_strobe low)
-    rmw(0x04, 1 << 16, 0);          // RFEND+0x04 clear bit16 (RX_ADC_config reset)
-    rmw(0x0C, 0, 1 << 8);           // RFEND+0x0C set bit8 (ADC_ref_strobe high = latch)
-    rmw(0x04, 0, 1 << 16);          // RFEND+0x04 set bit16 (RX_ADC_config apply)
+    rmw(0x58, 1 << 16, 0);          // clear bit16 (RX_ADC_ref disable)
+    rmw(0x08, 0, 1 << 16);          // set bit16 (RX_ADC path enable)
+    rmw(0x0C, 1 << 8, 0);           // clear bit8 (ADC_ref_strobe low)
+    rmw(0x04, 1 << 16, 0);          // clear bit16 (RX_ADC_config reset)
+    rmw(0x0C, 0, 1 << 8);           // set bit8 (ADC_ref_strobe high = latch)
+    rmw(0x04, 0, 1 << 16);          // set bit16 (RX_ADC_config apply)
 }

--- a/src/ble/regint.rs
+++ b/src/ble/regint.rs
@@ -1,0 +1,265 @@
+// BLE_RegInit — RF calibration for CH32V208 BLE.
+//
+// Implements the 4 calibration functions called by BLE_RegInit() in libwchble.a V1.40:
+//   1. RFEND_TXCtune  — TX carrier + gain calibration (40-channel lookup table)
+//   2. RFEND_TXFtune  — TX filter enable (trivial: set one bit)
+//   3. RFEND_RXFilter — RX filter self-calibration with hardware poll
+//   4. RFEND_RXAdc    — RX ADC reference configuration
+//
+// All calibration functions use gptrRFENDReg (0x40025000) as the RFEND base.
+// This is DISTINCT from the RFEND_DevInit base at 0x40024300 (gptrAESReg).
+//
+// Register intent map (from disassembly of libwchble.a V1.40, confirmed):
+//   RFEND+0x04  bits: bit0=TX_tune_trigger, bit4=TX_cal_mode, bit8=TXF_enable,
+//                     bit12=RX_filter_mode, bit16=RX_ADC_config
+//   RFEND+0x08  bits: bit16=RX_ADC_path, bit17=TX_cal_path, bit21=RX_filter_path
+//   RFEND+0x0C  bits: bit4=RX_filter_strobe, bit8=ADC_ref_strobe
+//   RFEND+0x28  bits: bit12=TX_tune_mode_final (set after calibration completes)
+//   RFEND+0x2C  bits: bit4=post_cal_enable
+//   RFEND+0x38  bits[15:8]=freq_code, bits[5:0]=nCO2440, bits[30:24]=nGA2440
+//   RFEND+0x50  bits: bit16=RX_filter_valid, bits[4:0]=RX_filter_result
+//   RFEND+0x58  bits: bit16=RX_ADC_ref_enable
+//   RFEND+0x90  bits: bits[5:0]=CO_result, bit25=tune_done, bit26=tune_active
+//   RFEND+0x94  bits[16:10]: GA_result (7 bits)
+//   RFEND+0x9C  bits: bit8=RX_filter_done, bits[4:0]=RX_filter_result
+//   RFEND+0xA0..0xB0: CO calibration table 1 (nibble-packed, 40 channels, ch0→ch39)
+//   RFEND+0xB4..0xC4: CO calibration table 2 (nibble-packed, 40 channels, ch0→ch39)
+//   RFEND+0xC8..0xD0: GA calibration + CO overflow (partially reversed, see TODO)
+//
+// Sources: static disassembly of dtm.elf (WCH BLE SDK V1.40), live register dump.
+
+use core::arch::asm;
+use core::ptr::{read_volatile, write_volatile};
+
+// gptrRFENDReg: PA bias, PLL, channel lock, calibration tables.
+const RFEND_BASE: usize = 0x40025000;
+// gptrLLEReg: provides LLE+0x64 countdown register for calibration timeouts.
+const LLE_BASE: usize = 0x40024200;
+
+// Magic cookie: if ftuneFlag matches this value, RFEND_TXCtune skips re-measurement
+// and reuses cached nCO/nGA values from the previous calibration run.
+// Writing 0 to ftuneFlag forces a fresh calibration on next call.
+// WCH stores ftuneFlag at a fixed RAM address; we always run fresh.
+
+#[inline(always)]
+unsafe fn r(off: usize) -> u32 {
+    read_volatile((RFEND_BASE + off) as *const u32)
+}
+
+#[inline(always)]
+unsafe fn w(off: usize, val: u32) {
+    write_volatile((RFEND_BASE + off) as *mut u32, val);
+}
+
+#[inline(always)]
+unsafe fn rmw(off: usize, clear: u32, set: u32) {
+    w(off, (r(off) & !clear) | set);
+}
+
+/// Run all 4 RF calibration routines in the order used by BLE_RegInit.
+///
+/// Must be called after `ble_phy_init()` (RFEND_DevInit + BB_DevInit + LLE_DevInit).
+/// Calibrates TX carrier, TX filter, RX filter, and RX ADC for the current temperature.
+///
+/// # Safety
+/// Requires the RFEND/LLE peripherals to be initialized and accessible.
+pub unsafe fn ble_reg_init() {
+    rfend_tx_ctune();
+    rfend_tx_ftune();
+    rfend_rx_filter();
+    rfend_rx_adc();
+}
+
+/// RFEND_TXCtune: TX carrier oscillator + gain calibration.
+///
+/// Measures CO (carrier offset, bits[5:0] of RFEND+0x90) and GA (gain adjust,
+/// bits[16:10] of RFEND+0x94) at 3 reference frequencies (2401, 2480, 2440 MHz),
+/// then linearly interpolates two 40-channel nibble-packed lookup tables.
+///
+/// After calibration, RFEND+0x38 stores nCO2440 in bits[5:0] and nGA2440 in
+/// bits[30:24] as the default channel configuration.
+unsafe fn rfend_tx_ctune() {
+    // Setup: clear calibration-mode bits, enable TX cal path.
+    // RFEND+0x04 clear bit8 (TXF enable off during CO tune)
+    rmw(0x04, 1 << 8, 0);
+    // RFEND+0x28 clear bit12 (TX tune mode not yet final)
+    rmw(0x28, 1 << 12, 0);
+    // RFEND+0x2C clear bits[3:0]
+    rmw(0x2C, 0xF, 0);
+    // RFEND+0x08 set bit17 (TX calibration path enable)
+    rmw(0x08, 0, 1 << 17);
+    // RFEND+0x04 set bit4 (TX calibration mode)
+    rmw(0x04, 0, 1 << 4);
+
+    // Measure CO and GA at 3 reference frequencies.
+    // Freq codes for RFEND+0x38 bits[15:8]: confirmed from BB_DevInit/RF_DevSetChannel.
+    //   0xBF = 191 → 2401 MHz  (one step below BLE ch0 at 2402 MHz)
+    //   0xE7 = 231 → 2480 MHz  (= BLE ch39)
+    //   0xD3 = 211 → 2440 MHz  (≈ BLE ch19, midpoint)
+    let (nco2401, nga2401) = tx_tune_measure(0xBF00);
+    let (nco2480, nga2480) = tx_tune_measure(0xE700);
+    let (nco2440, nga2440) = tx_tune_measure(0xD300);
+
+    // CO table 1 (RFEND+0xA0..0xB0, 5 words, 40 nibbles for ch0..ch39).
+    // Linear interpolation anchored at nCO2401 (ch0) and nCO2440 (ch19):
+    //   CO1[0]  = (nco2401 - nco2440) & 0xF          (raw delta, ch0)
+    //   CO1[ch] = (nco2401 - nco2440) * (39-ch) / 39  for ch = 1..39
+    // Confirmed: live dump CO1[0]=6, CO1[39]=0, monotone decreasing.
+    let delta_low = nco2401 as i32 - nco2440 as i32;
+    for word in 0..5usize {
+        let mut word_val = 0u32;
+        for i in 0..8usize {
+            let ch = word * 8 + i;
+            let nibble = if ch == 0 {
+                (delta_low & 0xF) as u32
+            } else {
+                ((delta_low * (39 - ch as i32) / 39) & 0xF) as u32
+            };
+            word_val |= nibble << (i * 4);
+        }
+        w(0xA0 + word * 4, word_val);
+    }
+
+    // CO table 2 (RFEND+0xB4..0xC4, 5 words, 40 nibbles for ch0..ch39).
+    // Anchored at nCO2440 and nCO2480:
+    //   CO2[ch] = (nco2440 - nco2480) * (ch+1) / 40  for ch = 0..39
+    // Confirmed: live dump CO2[0]=0, CO2[39]=7, monotone increasing.
+    let delta_high = nco2440 as i32 - nco2480 as i32;
+    for word in 0..5usize {
+        let mut word_val = 0u32;
+        for i in 0..8usize {
+            let ch = word * 8 + i;
+            let nibble = ((delta_high * (ch as i32 + 1) / 40) & 0xF) as u32;
+            word_val |= nibble << (i * 4);
+        }
+        w(0xB4 + word * 4, word_val);
+    }
+
+    // CO2 overflow: 2 extra entries at RFEND+0xC8 nibbles 0-1 (ch40, ch41).
+    // The hardware reads up to ch41 for guard-band / out-of-band channels.
+    let co2_ch40 = ((delta_high * 41 / 40) & 0xF) as u32;
+    let co2_ch41 = ((delta_high * 42 / 40) & 0xF) as u32;
+    let prev_c8 = r(0xC8);
+    w(0xC8, (prev_c8 & !0xFF) | co2_ch40 | (co2_ch41 << 4));
+
+    // TODO: GA calibration table at RFEND+0xC8 nibbles 2..7 and RFEND+0xCC..0xD0.
+    // GA nibbles use delta_ga = nga2440 - nga2480 divided by delta_co_high,
+    // with a minimum bias of |8 per nibble (keeps encoded GA values ≥ 8).
+    // Multipliers per nibble (from assembly): 10, 9, 8, sll×3, ...
+    // Formula confirmed for nibble2: (delta_ga * 10 / delta_high | 8) & 0xF.
+    // Full multiplier sequence and second GA table (using nga2401-nga2440) need
+    // further analysis. TX operates without GA calibration (affects gain flatness only).
+    let _ = (nga2401, nga2480); // suppress unused warnings until GA is implemented
+
+    // Teardown: clear calibration mode, switch to operational state.
+    rmw(0x04, (1 << 4) | 1, 0); // clear bit4 (TX_cal_mode) and bit0 (trigger)
+    rmw(0x28, 0, 1 << 12);       // set bit12 (TX_tune_mode_final)
+    rmw(0x2C, 0, 1 << 4);        // set bit4 (post_cal_enable)
+
+    // Store calibration anchors: nCO2440 in RFEND+0x38 bits[5:0], nGA2440 in bits[30:24].
+    // Hardware reads these on every TX burst for default channel compensation.
+    let v = r(0x38);
+    let v = (v & !0x3F) | (nco2440 as u32 & 0x3F);
+    let v = (v & 0x80FF_FFFF) | ((nga2440 as u32 & 0x7F) << 24);
+    w(0x38, v);
+}
+
+/// Perform one TX tune measurement at the given frequency code.
+///
+/// `freq_code`: 16-bit value with bits[15:8] = frequency select code.
+///   0xBF00 = 2401 MHz, 0xE700 = 2480 MHz, 0xD300 = 2440 MHz.
+///
+/// Returns (CO result [5:0], GA result [6:0]) after hardware tune completion.
+#[inline]
+unsafe fn tx_tune_measure(freq_code: u32) -> (u8, u8) {
+    // Clear bit0 (deassert previous trigger), set freq code, assert trigger.
+    rmw(0x04, 1, 0);
+    let v = r(0x38);
+    w(0x38, (v & 0xFFFE_00FF) | freq_code); // bits[16:8] → freq code
+    rmw(0x04, 0, 1);
+
+    rfend_wait_tune();
+
+    let co = (r(0x90) & 0x3F) as u8;        // bits[5:0] of RFEND+0x90
+    let ga = ((r(0x94) >> 10) & 0x7F) as u8; // bits[16:10] of RFEND+0x94
+    (co, ga)
+}
+
+/// Poll for TX tune completion using the LLE countdown timer as timeout.
+///
+/// RFEND+0x90 bit26 = tune phase active; bit25 = tune done.
+/// LLE+0x64 is used as a software countdown written before polling.
+#[inline]
+unsafe fn rfend_wait_tune() {
+    write_volatile((LLE_BASE + 0x64) as *mut u32, 6000);
+    loop {
+        let status = r(0x90);
+        if status & (1 << 26) != 0 && status & (1 << 25) != 0 {
+            return; // active phase + done flag both set
+        }
+        let countdown = read_volatile((LLE_BASE + 0x64) as *const u32);
+        if countdown == 0 {
+            return; // timeout
+        }
+    }
+}
+
+/// RFEND_TXFtune: enable TX filter.
+///
+/// Trivial: set bit8 of RFEND+0x04 (TXF_enable).
+/// From RFEND_TXFtune() at 0xf8c2 in dtm.elf.
+unsafe fn rfend_tx_ftune() {
+    rmw(0x04, 0, 1 << 8);
+}
+
+/// RFEND_RXFilter: RX filter self-calibration.
+///
+/// Hardware self-calibrates the RX filter, polls RFEND+0x9C bit8 for done,
+/// then stores the result bits[4:0] into RFEND+0x50 bits[4:0].
+/// From RFEND_RXFilter() at 0xead4 in dtm.elf.
+unsafe fn rfend_rx_filter() {
+    // Enable RX filter path and trigger calibration strobe.
+    rmw(0x50, 1 << 16, 0);          // RFEND+0x50 clear bit16 (RX_filter_valid)
+    rmw(0x08, 0, 1 << 21);          // RFEND+0x08 set bit21 (RX_filter_path enable)
+    rmw(0x0C, 0, 1 << 4);           // RFEND+0x0C set bit4 (strobe high)
+    rmw(0x0C, 1 << 4, 0);           // RFEND+0x0C clear bit4 (strobe low)
+    // 4-cycle delay for strobe settle.
+    for _ in 0..4 {
+        unsafe { asm!("nop") };
+    }
+    rmw(0x0C, 0, 1 << 4);           // RFEND+0x0C set bit4 (second strobe = actual trigger)
+    rmw(0x04, 0, 1 << 12);          // RFEND+0x04 set bit12 (RX_filter_mode)
+
+    // Poll for done: RFEND+0x9C bit8, countdown from LLE+0x64 = 80.
+    write_volatile((LLE_BASE + 0x64) as *mut u32, 80);
+    loop {
+        if r(0x9C) & (1 << 8) != 0 {
+            break; // calibration done
+        }
+        let countdown = read_volatile((LLE_BASE + 0x64) as *const u32);
+        if countdown == 0 {
+            break; // timeout
+        }
+    }
+
+    // Store calibration result: RFEND+0x50 = (prev | bit16) with bits[4:0] = result.
+    let result = r(0x9C) & 0x1F;
+    let v = r(0x50);
+    w(0x50, (v | (1 << 16)) & !0x1F | result);
+
+    rmw(0x08, 1 << 21, 0);          // RFEND+0x08 clear bit21 (disable RX filter path)
+}
+
+/// RFEND_RXAdc: configure RX ADC reference.
+///
+/// Clears and re-sets control bits in RFEND+0x58, 0x08, 0x0C, 0x04 to latch
+/// the ADC reference configuration. No wait loop.
+/// From RFEND_RXAdc() at 0xeb68 in dtm.elf.
+unsafe fn rfend_rx_adc() {
+    rmw(0x58, 1 << 16, 0);          // RFEND+0x58 clear bit16 (RX_ADC_ref disable)
+    rmw(0x08, 0, 1 << 16);          // RFEND+0x08 set bit16 (RX_ADC path enable)
+    rmw(0x0C, 1 << 8, 0);           // RFEND+0x0C clear bit8 (ADC_ref_strobe low)
+    rmw(0x04, 1 << 16, 0);          // RFEND+0x04 clear bit16 (RX_ADC_config reset)
+    rmw(0x0C, 0, 1 << 8);           // RFEND+0x0C set bit8 (ADC_ref_strobe high = latch)
+    rmw(0x04, 0, 1 << 16);          // RFEND+0x04 set bit16 (RX_ADC_config apply)
+}

--- a/src/ble/regint.rs
+++ b/src/ble/regint.rs
@@ -253,17 +253,23 @@ unsafe fn tx_tune_measure(freq_code: u32) -> (u8, u8) {
 ///
 /// Returns `true` if tune completed, `false` on timeout (LLE+0x64 reaches 0).
 #[inline]
+/// Poll for TX tune completion.
+///
+/// LLE+0x64 is event-driven (ticks only during active BLE events) so a software
+/// iteration counter is used instead of the original LLE countdown timeout.
+/// In practice, RFEND+0x90 bits 26+25 are set immediately after trigger assertion.
+#[inline]
 unsafe fn rfend_wait_tune() -> bool {
-    write_volatile((LLE_BASE + 0x64) as *mut u32, 6000);
-    loop {
+    for _ in 0..200_000u32 {
         let status = r(0x90);
         if status & (1 << 26) != 0 && status & (1 << 25) != 0 {
             return true;
         }
-        if read_volatile((LLE_BASE + 0x64) as *const u32) == 0 {
-            return false;
-        }
+        core::hint::spin_loop();
     }
+    #[cfg(feature = "defmt")]
+    defmt::warn!("rfend_wait_tune timeout");
+    false
 }
 
 /// RFEND_TXFtune: enable TX filter.
@@ -292,16 +298,18 @@ unsafe fn rfend_rx_filter() {
     rmw(0x0C, 0, 1 << 4);           // second strobe = actual calibration trigger
     rmw(0x04, 0, 1 << 12);          // set bit12 (RX_filter_mode)
 
-    write_volatile((LLE_BASE + 0x64) as *mut u32, 80);
-    loop {
+    // LLE+0x64 is event-driven (ticks only during active BLE events); use a software counter.
+    let mut filter_done = false;
+    for _ in 0..200_000u32 {
         if r(0x9C) & (1 << 8) != 0 {
+            filter_done = true;
             break;
         }
-        if read_volatile((LLE_BASE + 0x64) as *const u32) == 0 {
-            #[cfg(feature = "defmt")]
-            defmt::warn!("rfend_rx_filter timeout");
-            break;
-        }
+        core::hint::spin_loop();
+    }
+    #[cfg(feature = "defmt")]
+    if !filter_done {
+        defmt::warn!("rfend_rx_filter timeout");
     }
 
     let result = r(0x9C) & 0x1F;

--- a/src/ble/regint.rs
+++ b/src/ble/regint.rs
@@ -142,14 +142,49 @@ unsafe fn rfend_tx_ctune() {
     let prev_c8 = r(0xC8);
     w(0xC8, (prev_c8 & !0xFF) | co2_ch40 | (co2_ch41 << 4));
 
-    // TODO: GA calibration table at RFEND+0xC8 nibbles 2..7 and RFEND+0xCC..0xD0.
-    // GA nibbles use delta_ga = nga2440 - nga2480 divided by delta_co_high,
-    // with a minimum bias of |8 per nibble (keeps encoded GA values ≥ 8).
-    // Multipliers per nibble (from assembly): 10, 9, 8, sll×3, ...
-    // Formula confirmed for nibble2: (delta_ga * 10 / delta_high | 8) & 0xF.
-    // Full multiplier sequence and second GA table (using nga2401-nga2440) need
-    // further analysis. TX operates without GA calibration (affects gain flatness only).
-    let _ = (nga2401, nga2480); // suppress unused warnings until GA is implemented
+    // GA table segment 1 (0xC8 nibbles 2-7, 0xCC nibbles 0-3):
+    // Multipliers 10→1 descending, divisor=delta_high, |8 minimum bias.
+    // GA1[n] = (delta_ga * (10-n) / delta_high | 8) & 0xF, n=0..9
+    let delta_ga = nga2440 as i32 - nga2480 as i32;
+    {
+        // 0xC8 nibbles 2-7 (n=0..5, mult=10..5): preserve CO2 overflow in nibbles 0-1.
+        let mut v = r(0xC8);
+        for n in 0..6usize {
+            let mult = (10 - n) as i32;
+            let nib = ((delta_ga * mult / delta_high | 8) & 0xF) as u32;
+            let pos = (n + 2) * 4;
+            v = (v & !(0xF << pos)) | (nib << pos);
+        }
+        w(0xC8, v);
+    }
+    {
+        // 0xCC: nibbles 0-3 (GA1 n=6..9, mult=4..1), nibble4=0, nibbles 5-7 (GA2 n=0..2, mult=1..3).
+        // GA segment 2: delta_ga2 = nGA2401-nGA2440, divisor=delta_low (=nCO2401-nCO2440).
+        // GA2[n] = (delta_ga2 * (n+1) / delta_low) & 0xF  — no |8 bias.
+        let delta_ga2 = nga2401 as i32 - nga2440 as i32;
+        let mut v = r(0xCC);
+        for n in 0..4usize {
+            let mult = (4 - n) as i32;
+            let nib = ((delta_ga * mult / delta_high | 8) & 0xF) as u32;
+            v = (v & !(0xF << (n * 4))) | (nib << (n * 4));
+        }
+        v &= !(0xF << 16); // nibble 4 = 0 (separator between the two GA segments)
+        for n in 0..3usize {
+            let mult = (n + 1) as i32;
+            let nib = ((delta_ga2 * mult / delta_low) & 0xF) as u32;
+            v = (v & !(0xF << ((n + 5) * 4))) | (nib << ((n + 5) * 4));
+        }
+        w(0xCC, v);
+        // 0xD0 nibbles 0-6 (GA2 n=3..9, mult=4..10); nibble7 cleared to 0.
+        let mut v = r(0xD0);
+        for n in 0..7usize {
+            let mult = (n + 4) as i32;
+            let nib = ((delta_ga2 * mult / delta_low) & 0xF) as u32;
+            v = (v & !(0xF << (n * 4))) | (nib << (n * 4));
+        }
+        v &= !(0xF << 28);
+        w(0xD0, v);
+    }
 
     // Teardown: clear calibration mode, switch to operational state.
     rmw(0x04, (1 << 4) | 1, 0); // clear bit4 (TX_cal_mode) and bit0 (trigger)

--- a/src/ble/rfend.rs
+++ b/src/ble/rfend.rs
@@ -1,0 +1,82 @@
+// RFEND (RF Frontend) initialization for CH32V208 BLE.
+//
+// Register base: 0x40024300
+// Source: elec-docs/ble-reverse-docs/04-rfend-registers.md and 24-rf-phy-supplement.md
+// Derived from RFEND_DevInit / RFEND_Reset in libwchble.a V1.40 (rfend.o)
+
+use core::arch::asm;
+use core::ptr::{read_volatile, write_volatile};
+
+const RFEND_BASE: usize = 0x40024300;
+
+#[inline(always)]
+unsafe fn rfend_read(offset: usize) -> u32 {
+    read_volatile((RFEND_BASE + offset) as *const u32)
+}
+
+#[inline(always)]
+unsafe fn rfend_write(offset: usize, val: u32) {
+    write_volatile((RFEND_BASE + offset) as *mut u32, val);
+}
+
+#[inline(always)]
+unsafe fn rfend_modify(offset: usize, clear: u32, set: u32) {
+    let v = rfend_read(offset);
+    rfend_write(offset, (v & !clear) | set);
+}
+
+/// Reset the RF frontend.
+///
+/// Sequence from RFEND_Reset() (rfend.o): write 0x1101 → delay → write 0x0000 → delay → write 0x1101.
+/// Hardware-confirmed reset value 0x1101 sets CTRL bits [12, 8, 0].
+pub unsafe fn rfend_reset() {
+    const CTRL: usize = 0x0C;
+    rfend_write(CTRL, 0x1101);
+    for _ in 0..20 {
+        asm!("nop");
+    }
+    rfend_write(CTRL, 0x0000);
+    for _ in 0..20 {
+        asm!("nop");
+    }
+    rfend_write(CTRL, 0x1101);
+}
+
+/// Initialize the RF frontend.
+///
+/// Mirrors RFEND_DevInit() from libwchble.a V1.40 (rfend.o, line 77124).
+/// Configures CFG0, RF0, RF1, RF2, RF3, CFG4, CFG5 for normal BLE operation.
+pub unsafe fn rfend_dev_init() {
+    rfend_reset();
+
+    // CFG0 (+0x28): default value 0x480, confirmed by hardware dump
+    rfend_write(0x28, 0x480);
+
+    // RF0 (+0x48): multi-field analog RF configuration
+    rfend_modify(0x48, 0x7000_0000, 0x2000_0000); // bits[30:28]: set bit29 only
+    rfend_modify(0x48, 0x0700_0000, 0x0400_0000); // bits[26:24] = 0b100
+    rfend_modify(0x48, 0x0000_000F, 0x0000_0009); // bits[3:0] = 9
+    rfend_modify(0x48, 0x000F_0000, 0x0000_0000); // bits[19:16] = 0
+    rfend_modify(0x48, 0x0000_0000, 0x8000_0000); // bit31 = 1
+
+    // RF1 (+0x4C): bias/filter configuration
+    rfend_modify(0x4C, 0x07, 0x03); // bits[2:0] = 3
+    rfend_modify(0x4C, 0x70, 0x30); // bits[6:4] = 3
+    rfend_modify(0x4C, 0x700, 0x300); // bits[10:8] = 3
+    rfend_modify(0x4C, 0x0100_0000, 0x0000_0000); // bit24 = 0
+    rfend_modify(0x4C, 0x0000_0000, 0x0020_0000); // bit21 = 1
+
+    // RF2 (+0x50): receiver configuration
+    rfend_modify(0x50, 0x0000_F000, 0x0000_1000); // bits[15:12] = 1
+    rfend_modify(0x50, 0x0000_000F, 0x0000_000C); // bits[3:0] = 12
+    rfend_modify(0x50, 0x0000_0000, 0x0000_0080); // bit7 = 1
+    rfend_modify(0x50, 0x0000_1000, 0x0000_0000); // bit12 = 0
+
+    // CFG5 (+0x3C): additional RF configuration
+    rfend_modify(0x3C, 0x0000_F000, 0x0000_8000); // bits[15:12] = 8
+    rfend_modify(0x3C, 0x0700_0000, 0x0200_0000); // bits[26:24]
+    rfend_modify(0x3C, 0x6000_0000, 0x4000_0000); // bit30 = 1
+
+    // CFG4 (+0x38): enable bit
+    rfend_modify(0x38, 0x0000_0000, 0x8000_0000); // bit31 = 1
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,15 @@ pub mod can;
 #[cfg(flash)]
 pub mod flash;
 
+// BLE PHY initialization — CH32V208 only (has BLE hardware at 0x40024100-0x40025000)
+#[cfg(any(
+    feature = "ch32v208cbu6",
+    feature = "ch32v208gbu6",
+    feature = "ch32v208rbt6",
+    feature = "ch32v208wbu6",
+))]
+pub mod ble;
+
 #[cfg(feature = "embassy")]
 pub mod embassy;
 

--- a/src/rcc/v0.rs
+++ b/src/rcc/v0.rs
@@ -94,7 +94,16 @@ pub(crate) unsafe fn init(config: Config) {
             w.set_hsebyp(config.hse.unwrap().mode == HseMode::Bypass);
             w.set_hseon(true);
         });
-        while !RCC.ctlr().read().hserdy() {}
+        // Wait for HSE ready with a bounded timeout (~50 ms at 8 MHz HSI).
+        let mut timeout = 400_000u32;
+        while !RCC.ctlr().read().hserdy() {
+            timeout = timeout.wrapping_sub(1);
+            if timeout == 0 {
+                panic!("HSE oscillator failed to start (HSERDY never set). \
+                        Check that a crystal is populated and properly \
+                        connected to OSC_IN/OSC_OUT.");
+            }
+        }
     }
 
     let sysclk = match config.sys {

--- a/src/rcc/v1.rs
+++ b/src/rcc/v1.rs
@@ -140,7 +140,16 @@ pub(crate) unsafe fn init(config: Config) {
         Some(hse) => {
             RCC.ctlr().modify(|w| w.set_hsebyp(hse.mode != HseMode::Oscillator));
             RCC.ctlr().modify(|w| w.set_hseon(true));
-            while !RCC.ctlr().read().hserdy() {}
+            // Wait for HSE ready with a bounded timeout (~50 ms at 8 MHz HSI).
+            let mut timeout = 400_000u32;
+            while !RCC.ctlr().read().hserdy() {
+                timeout = timeout.wrapping_sub(1);
+                if timeout == 0 {
+                    panic!("HSE oscillator failed to start (HSERDY never set). \
+                            Check that a crystal is populated and properly \
+                            connected to OSC_IN/OSC_OUT.");
+                }
+            }
             Some(hse.freq)
         }
     };

--- a/src/rcc/v3.rs
+++ b/src/rcc/v3.rs
@@ -250,7 +250,7 @@ pub(crate) unsafe fn init(config: Config) {
                 timeout = timeout.wrapping_sub(1);
                 if timeout == 0 {
                     panic!("HSE oscillator failed to start (HSERDY never set). \
-                            Check that a 32 MHz crystal is populated and properly \
+                            Check that the crystal is populated and properly \
                             connected to OSC_IN/OSC_OUT.");
                 }
             }

--- a/src/rcc/v3.rs
+++ b/src/rcc/v3.rs
@@ -242,7 +242,18 @@ pub(crate) unsafe fn init(config: Config) {
         Some(hse) => {
             RCC.ctlr().modify(|w| w.set_hsebyp(hse.mode != HseMode::Oscillator));
             RCC.ctlr().modify(|w| w.set_hseon(true));
-            while !RCC.ctlr().read().hserdy() {}
+            // Wait for HSE ready with a bounded timeout (~50 ms at 8 MHz HSI).
+            // An infinite spin is dangerous on boards without an external crystal
+            // or with a missing/damaged oscillator circuit.
+            let mut timeout = 400_000u32;
+            while !RCC.ctlr().read().hserdy() {
+                timeout = timeout.wrapping_sub(1);
+                if timeout == 0 {
+                    panic!("HSE oscillator failed to start (HSERDY never set). \
+                            Check that a 32 MHz crystal is populated and properly \
+                            connected to OSC_IN/OSC_OUT.");
+                }
+            }
             Some(hse.freq)
         }
     };


### PR DESCRIPTION
## Summary

Implements BLE hardware initialization and RF calibration for CH32V208, reverse-engineered from `libwchble.a` V1.40 and verified by SDR measurement.

### Phase 1: PHY init + DTM TX (verified)

- `src/ble/rfend.rs` — `rfend_dev_init()`: RF frontend reset + analog config (mirrors `RFEND_DevInit`)
- `src/ble/bb.rs` — `bb_dev_init()`: baseband config, `BB_RF_FLAG_1M = 0x09` (corrected from 0x00; confirmed from live dtm.elf register dump)
- `src/ble/lle.rs` — `lle_dev_init()`: link layer engine timing + IRQ mask
- `src/ble/regint.rs` — `ble_reg_init()`: RF calibration — CO tables (carrier offset, 40 nibbles each) + GA tables (gain amplitude, two segments with/without |8 bias), 3-point measurement at 2401/2480/2440 MHz
- `src/ble/mod.rs` — `ble_phy_init()`: unified init in correct order (LLE→RFEND→BB), calls `ble_reg_init()` at end
- `examples/ch32v208/src/bin/ble_dtm_tx.rs` — DTM continuous TX example, round-robin on 2406/2440/2472 MHz

**SDR verification (HackRF One, ON/OFF differential + calibration A/B):**
- RF path confirmed: 2406 MHz +10.6 dB, 2472 MHz +12.6 dB above ambient baseline
- Calibration verified by A/B (`ble_reg_init` on vs off):
  - Carrier frequency: ±4–6 MHz uncorrected → <1 MHz with CO calibration (2472 MHz signal shifts to 2467–2476 MHz without calibration)
  - CO correction proportional to distance from anchor points (2406 near 2401 anchor = small drift; 2472 in 2440–2480 interpolation range = large drift) — directly validates the CO table interpolation model
  - Gain flatness: 2.0 dB across 2406–2472 MHz with full calibration
- 8100+ DTM TX bursts, 0 timeout (logic layer, pre-SDR)
- Note: 2440 MHz unobservable due to WiFi ch7 overlap

**Key fixes from reverse engineering:**
- `BB_RF_FLAG_1M = 0x09` (was 0x00; missing bits[30:25] disabled TX_DONE IRQ)
- BB/LLE register base addresses were swapped (0x40024100 ↔ 0x40024200)
- Init order: LLE must precede BB GO strobe
- NVIC IRQ not enabled (polling path; enabling without handlers causes faults)

### Phase 2: ADV_NONCONN_IND skeleton (compiles, board test pending)

- `src/ble/adv.rs` — `adv_event()`: ADV_NONCONN_IND on ch37/38/39, whitening enabled via `LLE+0x00 bit6` (confirmed from `RF_DevSetChannel` d.asm 71418), AD structure helpers
- `examples/ch32v208/src/bin/ble_adv.rs` — broadcasts "ch32-hal", verifiable with nRF Connect

## Test plan

- [x] DTM TX: 8100+ bursts, 0 timeout via SDI print
- [x] SDR ON/OFF differential: signals confirmed at 2406/2472 MHz
- [x] Calibration A/B: CO correction effect confirmed by carrier frequency measurement
- [ ] ADV_NONCONN_IND: flash `ble_adv`, confirm "ch32-hal" appears in nRF Connect (hardware test pending)
- [ ] SDR gain flatness at 2472: narrow-band verification for BLE spec compliance claim

## Commits

- `fe8cb9f` feat(ble): add CH32V208 BLE PHY initialization (Phase 1)
- `72353f0` WIP: fix BLE TX — correct BB_RF_FLAG and register bases
- `a62ed6a` WIP: add BLE_RegInit RF calibration — CO tables + TXFtune/RXFilter/RXAdc
- `9ade68c` ble: complete GA calibration table in regint.rs
- `046cd3e` ble: address regint.rs review feedback (RFEND_CAL_BASE rename, defmt timeouts, dead code, freq constants)
- `b7186e3` ble/regint: guard GA tables against divide-by-zero
- `e9dba77` ble/regint: add debug_assert for GA2 nibble range
- `15ff6b4` ble: add ADV_NONCONN_IND advertising module (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)