### PR TITLE
Fix V00X crash at 48MHz, and RS485 style UART blocking_flush bug.

### DIFF
--- a/src/rcc/v0.rs
+++ b/src/rcc/v0.rs
@@ -126,9 +126,27 @@ pub(crate) unsafe fn init(config: Config) {
         _ => unreachable!(),
     };
 
-    if sysclk >= 24_000_000 {
-        FLASH.actlr().modify(|w| w.set_latency(0b01)); // 1 等待（24MHz<HCLK≤48MHz）
-    }
+    // V003 RM section 16.3.1:
+    //   00: 0 wait (0  <= SYSCLK <= 24 MHz)
+    //   01: 1 wait (24 <  SYSCLK <= 48 MHz)
+    #[cfg(ch32v003)]
+    let latency = match sysclk {
+        0..=24_000_000 => 0b00,
+        _ => 0b01,
+    };
+
+    // V00x RM section 18.3.1:
+    //   00: 0 wait (0  <= SYSCLK <= 15 MHz)
+    //   01: 1 wait (15 <  SYSCLK <= 24 MHz)
+    //   10: 2 wait (24 <  SYSCLK <= 48 MHz)
+    #[cfg(any(ch32v002, ch32v004, ch32v005, ch32v006, ch32v007))]
+    let latency = match sysclk {
+        0..=15_000_000 => 0b00,
+        15_000_001..=24_000_000 => 0b01,
+        _ => 0b10,
+    };
+
+    FLASH.actlr().modify(|w| w.set_latency(latency));
 
     RCC.cfgr0().modify(|w| {
         w.set_hpre(config.ahb_pre);

--- a/src/usart/mod.rs
+++ b/src/usart/mod.rs
@@ -223,8 +223,7 @@ impl<'d, T: Instance, M: Mode> UartTx<'d, T, M> {
     /// Block until transmission complete
     pub fn blocking_flush(&mut self) -> Result<(), Error> {
         let rb = T::regs();
-
-        while !rb.statr().read().txe() {} // wait tx ends
+        while !rb.statr().read().tc() {} // wait for last bit on wire.
         Ok(())
     }
 }


### PR DESCRIPTION
This PR fixes two issues:

- V00X crash if clock speed is higher than 24Mhz. This is because V00X uses different flash latency values than V003.
- A small bug in UART where `blocking_flush` returns before last bit is on wire. This usually does not matter, but it shows up when using higher baud rate combined with RS485 style UART
