### PR TITLE
examples: drop stabilized feature flags and add wchisp runner

### DIFF
--- a/examples/ch32l103/src/bin/adc.rs
+++ b/examples/ch32l103/src/bin/adc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32l103/src/bin/adc_temp.rs
+++ b/examples/ch32l103/src/bin/adc_temp.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32l103/src/bin/blinky.rs
+++ b/examples/ch32l103/src/bin/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32l103/src/bin/blinky_raw.rs
+++ b/examples/ch32l103/src/bin/blinky_raw.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use hal::gpio::{Level, Output};
 use qingke::riscv;

--- a/examples/ch32l103/src/bin/rcc.rs
+++ b/examples/ch32l103/src/bin/rcc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32v003/src/bin/adc.rs
+++ b/examples/ch32v003/src/bin/adc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use hal::delay::Delay;
 use hal::gpio::{Level, Output};

--- a/examples/ch32v003/src/bin/blinky.rs
+++ b/examples/ch32v003/src/bin/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use hal::delay::Delay;
 use hal::gpio::{Level, Output};

--- a/examples/ch32v003/src/bin/embassy_blinky.rs
+++ b/examples/ch32v003/src/bin/embassy_blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use hal::Peri;

--- a/examples/ch32v003/src/bin/gpio_ws2812.rs
+++ b/examples/ch32v003/src/bin/gpio_ws2812.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use ch32_hal::gpio::Output;

--- a/examples/ch32v003/src/bin/pwm.rs
+++ b/examples/ch32v003/src/bin/pwm.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use hal::delay::Delay;
 use hal::time::Hertz;

--- a/examples/ch32v003/src/bin/spi-lcd-st7735-cube.rs
+++ b/examples/ch32v003/src/bin/spi-lcd-st7735-cube.rs
@@ -4,8 +4,8 @@
 
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embedded_graphics::pixelcolor::raw::ToBytes;

--- a/examples/ch32v003/src/bin/uart_tx.rs
+++ b/examples/ch32v003/src/bin/uart_tx.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use hal::delay::Delay;
 use hal::gpio::{Level, Output};

--- a/examples/ch32v103/src/bin/blinky.rs
+++ b/examples/ch32v103/src/bin/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use hal::gpio::{Level, Output};

--- a/examples/ch32v103/src/bin/pwm.rs
+++ b/examples/ch32v103/src/bin/pwm.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use hal::delay::Delay;
 use hal::println;

--- a/examples/ch32v103/src/bin/rcc.rs
+++ b/examples/ch32v103/src/bin/rcc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use hal::delay::Delay;

--- a/examples/ch32v203/src/bin/adc.rs
+++ b/examples/ch32v203/src/bin/adc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32v203/src/bin/blinky.rs
+++ b/examples/ch32v203/src/bin/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use hal::gpio::{Level, Output};
 use qingke::riscv;

--- a/examples/ch32v203/src/bin/flash_sections.rs
+++ b/examples/ch32v203/src/bin/flash_sections.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use hal::Peri;

--- a/examples/ch32v203/src/bin/spi-lcd-st7735.rs
+++ b/examples/ch32v203/src/bin/spi-lcd-st7735.rs
@@ -7,8 +7,8 @@
 
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use core::fmt::Write;
 

--- a/examples/ch32v203/src/bin/uart.rs
+++ b/examples/ch32v203/src/bin/uart.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal::usart;
 use embassy_executor::Spawner;

--- a/examples/ch32v208/src/bin/blinky.rs
+++ b/examples/ch32v208/src/bin/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use hal::gpio::{Level, Output};
 use hal::println;

--- a/examples/ch32v305/src/bin/adc.rs
+++ b/examples/ch32v305/src/bin/adc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32v305/src/bin/blinky.rs
+++ b/examples/ch32v305/src/bin/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};

--- a/examples/ch32v305/src/bin/demo.rs
+++ b/examples/ch32v305/src/bin/demo.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use hal::Peri;

--- a/examples/ch32v305/src/bin/exti.rs
+++ b/examples/ch32v305/src/bin/exti.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use hal::Peri;

--- a/examples/ch32v305/src/bin/i2c.rs
+++ b/examples/ch32v305/src/bin/i2c.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32v305/src/bin/rcc.rs
+++ b/examples/ch32v305/src/bin/rcc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};

--- a/examples/ch32v305/src/bin/spi-lcd-st7735-cube.rs
+++ b/examples/ch32v305/src/bin/spi-lcd-st7735-cube.rs
@@ -4,8 +4,8 @@
 
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use hal::Peri;

--- a/examples/ch32v305/src/bin/uart_echo.rs
+++ b/examples/ch32v305/src/bin/uart_echo.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};

--- a/examples/ch32v305/src/bin/uart_tx.rs
+++ b/examples/ch32v305/src/bin/uart_tx.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal::usart;
 use embassy_executor::Spawner;

--- a/examples/ch32v307/src/bin/adc.rs
+++ b/examples/ch32v307/src/bin/adc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32v307/src/bin/blinky.rs
+++ b/examples/ch32v307/src/bin/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use hal::delay::Delay;
 use hal::gpio::{Level, Output};

--- a/examples/ch32v307/src/bin/blinky_pwm.rs
+++ b/examples/ch32v307/src/bin/blinky_pwm.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;

--- a/examples/ch32v307/src/bin/button.rs
+++ b/examples/ch32v307/src/bin/button.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use core::sync::atomic::{AtomicU32, Ordering};
 

--- a/examples/ch32v307/src/bin/embassy_blinky.rs
+++ b/examples/ch32v307/src/bin/embassy_blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};

--- a/examples/ch32v307/src/bin/exti.rs
+++ b/examples/ch32v307/src/bin/exti.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use hal::Peri;

--- a/examples/ch32v307/src/bin/i2c-bmp180-async.rs
+++ b/examples/ch32v307/src/bin/i2c-bmp180-async.rs
@@ -1,8 +1,8 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
-#![feature(naked_functions)]
+
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32v307/src/bin/i2c-bmp180.rs
+++ b/examples/ch32v307/src/bin/i2c-bmp180.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32v307/src/bin/i2c-eeprom.rs
+++ b/examples/ch32v307/src/bin/i2c-eeprom.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use hal::Peri;

--- a/examples/ch32v307/src/bin/i2c-ssd1306.rs
+++ b/examples/ch32v307/src/bin/i2c-ssd1306.rs
@@ -11,8 +11,8 @@
 
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use embassy_executor::Spawner;
 

--- a/examples/ch32v307/src/bin/rcc.rs
+++ b/examples/ch32v307/src/bin/rcc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};

--- a/examples/ch32v307/src/bin/rng.rs
+++ b/examples/ch32v307/src/bin/rng.rs
@@ -1,8 +1,8 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
-#![feature(naked_functions)]
+
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32v307/src/bin/sdmmc.rs
+++ b/examples/ch32v307/src/bin/sdmmc.rs
@@ -1,8 +1,8 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
-#![feature(naked_functions)]
+
+
+
 
 use ch32_hal as hal;
 use ch32_hal::sdio::Sdmmc;

--- a/examples/ch32v307/src/bin/spi.rs
+++ b/examples/ch32v307/src/bin/spi.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal::spi;
 use embassy_executor::Spawner;

--- a/examples/ch32v307/src/bin/uart.rs
+++ b/examples/ch32v307/src/bin/uart.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal::usart;
 use embassy_executor::Spawner;

--- a/examples/ch32v307/src/bin/uart_echo.rs
+++ b/examples/ch32v307/src/bin/uart_echo.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};

--- a/examples/ch32x035/.cargo/config.toml
+++ b/examples/ch32x035/.cargo/config.toml
@@ -6,6 +6,7 @@ runner = "wlink flash --enable-sdi-print --watch-serial"
 # runner = "wlink -v flash --no-erase --dry-run"
 # runner = "probe-rs run --chip CH32V307"
 # runner = "wlink -v flash"
+# runner = "wchisp flash"
 
 # Use the following or build.rs
 #rustflags = [

--- a/examples/ch32x035/src/bin/blinky.rs
+++ b/examples/ch32x035/src/bin/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use hal::Peri;

--- a/examples/ch32x035/src/bin/blinky_pwm.rs
+++ b/examples/ch32x035/src/bin/blinky_pwm.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32x035/src/bin/exti.rs
+++ b/examples/ch32x035/src/bin/exti.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32x035/src/bin/spi-lcd-st7735.rs
+++ b/examples/ch32x035/src/bin/spi-lcd-st7735.rs
@@ -7,8 +7,8 @@
 
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use core::fmt::Write;
 

--- a/examples/ch32x035/src/bin/uart_echo.rs
+++ b/examples/ch32x035/src/bin/uart_echo.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32x035/src/bin/uart_pms7003_async.rs
+++ b/examples/ch32x035/src/bin/uart_pms7003_async.rs
@@ -1,8 +1,8 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
-#![feature(naked_functions)]
+
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32x035/src/bin/uart_rx.rs
+++ b/examples/ch32x035/src/bin/uart_rx.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32x035/src/bin/uart_tx.rs
+++ b/examples/ch32x035/src/bin/uart_tx.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/ch32x035/src/bin/uart_tx_async.rs
+++ b/examples/ch32x035/src/bin/uart_tx_async.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use core::arch::asm;
 

--- a/examples/ch641/src/bin/blinky.rs
+++ b/examples/ch641/src/bin/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use hal::delay::Delay;
 use hal::gpio::{Level, Output};

--- a/examples/ch641/src/bin/embassy_blinky.rs
+++ b/examples/ch641/src/bin/embassy_blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use ch32_hal as hal;
 use hal::Peri;

--- a/examples/ch641/src/bin/pwm.rs
+++ b/examples/ch641/src/bin/pwm.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
+
+
 
 use hal::delay::Delay;
 use hal::println;


### PR DESCRIPTION
## Summary
- Rebase of #126 (@wiktorpyk) onto current `main`; original PR was stale (last activity Jan 2026) and conflicted.
- Removes `#![feature(type_alias_impl_trait)]` and `#![feature(impl_trait_in_assoc_type)]` from example binaries so they build on stable Rust (both features are stabilized; the attrs are now an `E0554` hard error on stable and a `stable_features` warning on nightly).
- Adds a commented `wchisp flash` runner option to `examples/ch32x035/.cargo/config.toml`.
- Closes #125.

Changes vs. the original PR:
- Squashed 4 commits into 1 (the original branch had a `Fix cargo check` commit immediately reverted by the next commit — both dropped).
- Re-authored to credit @wiktorpyk via their GitHub noreply (originals used a placeholder `Your Name <you@example.com>`).

## Test plan
- [x] `cargo build --release` succeeds in `examples/ch32v003`, `examples/ch32x035`, `examples/ch32v307` (warnings only).
- [x] CI matrix passes on all 10 example targets.
- [x] Spot-check that a stable-channel build no longer hits `E0554` on a representative example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)