### PR TITLE
exti: gate driver and interrupt handlers behind `exti` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 
 [features]
-default = ["embassy", "rt"]
+default = ["embassy", "rt", "exti"]
 rt = ["dep:qingke-rt", "rt-wfi"]
 highcode = ["qingke-rt/highcode"]
 embassy = [
@@ -70,6 +70,8 @@ embassy = [
 ]
 defmt = ["dep:defmt"]
 memory-x = ["ch32-metapac/memory-x"]
+## Built-in EXTI driver and interrupt handlers. Disable to provide your own.
+exti = []
 
 
 # Features starting with `_` are for internal use only. They're not intended

--- a/examples/ch32v003/src/bin/exti.rs
+++ b/examples/ch32v003/src/bin/exti.rs
@@ -1,0 +1,28 @@
+#![no_std]
+#![no_main]
+
+use ch32_hal as hal;
+use embassy_executor::Spawner;
+use hal::exti::ExtiInput;
+use hal::gpio::{Level, Output, Pull};
+use hal::println;
+use panic_halt as _;
+
+#[embassy_executor::main(entry = "qingke_rt::entry")]
+async fn main(_spawner: Spawner) -> ! {
+    hal::debug::SDIPrint::enable();
+    let mut config = hal::Config::default();
+    config.rcc = hal::rcc::Config::SYSCLK_FREQ_48MHZ_HSI;
+    let p = hal::init(config);
+
+    println!("Wire a button from PC1 to GND. Each press toggles PD6.");
+
+    let mut led = Output::new(p.PD6, Level::Low, Default::default());
+    let mut button = ExtiInput::new(p.PC1, p.EXTI1, Pull::Up);
+
+    loop {
+        button.wait_for_falling_edge().await;
+        led.toggle();
+        println!("press");
+    }
+}

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -1,195 +1,4 @@
-use core::future::Future;
-use core::marker::PhantomData;
-use core::pin::Pin;
-use core::task::{Context, Poll};
-
-use embassy_sync::waitqueue::AtomicWaker;
-use qingke_rt::interrupt;
-
-use crate::gpio::{AnyPin, Input, Level, Pin as GpioPin, Pull};
-use crate::{impl_peripheral, peripherals, Peri};
-
-const EXTI_COUNT: usize = 24;
-const NEW_AW: AtomicWaker = AtomicWaker::new();
-static EXTI_WAKERS: [AtomicWaker; EXTI_COUNT] = [NEW_AW; EXTI_COUNT];
-
-pub unsafe fn on_irq() {
-    let exti = &crate::pac::EXTI;
-
-    let bits = exti.intfr().read();
-
-    // We don't handle or change any EXTI lines above 24.
-    let bits = bits.0 & 0x00FFFFFF;
-
-    // Clear pending - Clears the EXTI's line pending bits.
-    exti.intfr().write(|w| w.0 = bits);
-
-    exti.intenr().modify(|w| w.0 = w.0 & !bits);
-
-    // Wake the tasks
-    for pin in BitIter(bits) {
-        EXTI_WAKERS[pin as usize].wake();
-    }
-}
-
-struct BitIter(u32);
-
-impl Iterator for BitIter {
-    type Item = u32;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.0.trailing_zeros() {
-            32 => None,
-            b => {
-                self.0 &= !(1 << b);
-                Some(b)
-            }
-        }
-    }
-}
-
-/// EXTI input driver
-pub struct ExtiInput<'d> {
-    pin: Input<'d>,
-}
-
-impl<'d> Unpin for ExtiInput<'d> {}
-
-impl<'d> ExtiInput<'d> {
-    pub fn new<T: GpioPin>(
-        pin: Peri<'d, T>,
-        ch: Peri<'d, T::ExtiChannel>,
-        pull: Pull,
-    ) -> Self {
-        // Needed if using AnyPin+AnyChannel.
-        assert_eq!(pin.pin(), ch.number());
-
-        Self {
-            pin: Input::new(pin, pull),
-        }
-    }
-
-    pub fn is_high(&self) -> bool {
-        self.pin.is_high()
-    }
-
-    pub fn is_low(&self) -> bool {
-        self.pin.is_low()
-    }
-
-    pub fn get_level(&self) -> Level {
-        self.pin.get_level()
-    }
-
-    pub async fn wait_for_high<'a>(&'a mut self) {
-        let fut = ExtiInputFuture::new(self.pin.pin.pin.pin(), self.pin.pin.pin.port(), true, false);
-        if self.is_high() {
-            return;
-        }
-        fut.await
-    }
-
-    pub async fn wait_for_low<'a>(&'a mut self) {
-        let fut = ExtiInputFuture::new(self.pin.pin.pin.pin(), self.pin.pin.pin.port(), false, true);
-        if self.is_low() {
-            return;
-        }
-        fut.await
-    }
-
-    pub async fn wait_for_rising_edge<'a>(&'a mut self) {
-        ExtiInputFuture::new(self.pin.pin.pin.pin(), self.pin.pin.pin.port(), true, false).await
-    }
-
-    pub async fn wait_for_falling_edge<'a>(&'a mut self) {
-        ExtiInputFuture::new(self.pin.pin.pin.pin(), self.pin.pin.pin.port(), false, true).await
-    }
-
-    pub async fn wait_for_any_edge<'a>(&'a mut self) {
-        ExtiInputFuture::new(self.pin.pin.pin.pin(), self.pin.pin.pin.port(), true, true).await
-    }
-}
-
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-struct ExtiInputFuture<'a> {
-    pin: u8,
-    phantom: PhantomData<&'a mut AnyPin>,
-}
-
-// EXTI0-EXTI23 Px0-Px23（x=A/B/C）
-impl<'a> ExtiInputFuture<'a> {
-    fn new(pin: u8, port: u8, rising: bool, falling: bool) -> Self {
-        critical_section::with(|_| {
-            let exti = &crate::pac::EXTI;
-            let afio = &crate::pac::AFIO;
-
-            let port = port as u8;
-            let pin = pin as usize;
-
-            #[cfg(any(afio_v003, afio_v00x))]
-            {
-                // AFIO_EXTICR
-                // stride: 2, len: 15, 8 lines
-                afio.exticr().modify(|w| w.set_exti(pin, port));
-            }
-            // V1, V2, V3, L1
-            #[cfg(any(afio_v3, afio_l1))]
-            {
-                // AFIO_EXTICRx
-                // stride: 4, len: 4, 16 lines
-                afio.exticr(pin / 4).modify(|w| w.set_exti(pin % 4, port));
-            }
-            #[cfg(afio_x0)]
-            {
-                // stride: 2, len: 15, 24 lines
-                afio.exticr(pin / 16).modify(|w| w.set_exti(pin % 16, port));
-            }
-            #[cfg(afio_ch641)]
-            {
-                // single register
-                afio.exticr().modify(|w| w.set_exti(pin, port != 0));
-            }
-
-            // See-also: 7.4.3
-            exti.intenr().modify(|w| w.set_mr(pin, true)); // enable interrupt
-
-            exti.rtenr().modify(|w| w.set_tr(pin, rising));
-            exti.ftenr().modify(|w| w.set_tr(pin, falling));
-        });
-
-        Self {
-            pin,
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<'a> Drop for ExtiInputFuture<'a> {
-    fn drop(&mut self) {
-        critical_section::with(|_| {
-            let exti = &crate::pac::EXTI;
-            let pin = self.pin;
-            exti.intenr().modify(|w| w.0 = w.0 & !(1 << pin));
-        });
-    }
-}
-
-impl<'a> Future for ExtiInputFuture<'a> {
-    type Output = ();
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let exti = &crate::pac::EXTI;
-
-        EXTI_WAKERS[self.pin as usize].register(cx.waker());
-
-        if exti.intenr().read().mr(self.pin as _) == false {
-            // intenr cleared by on_irq, then we can assume it is triggered
-            Poll::Ready(())
-        } else {
-            Poll::Pending
-        }
-    }
-}
+use crate::{impl_peripheral, peripherals};
 
 trait SealedChannel {}
 
@@ -206,6 +15,7 @@ pub trait Channel: SealedChannel + embassy_hal_internal::PeripheralType + Sized 
 pub struct AnyChannel {
     number: u8,
 }
+
 impl_peripheral!(AnyChannel);
 impl SealedChannel for AnyChannel {}
 impl Channel for AnyChannel {
@@ -266,128 +76,331 @@ mod _exti_24lines {
     impl_exti!(EXTI23, 23);
 }
 
-/*
-EXTI0
-EXTI1
-EXTI2
-EXTI3
-EXTI4
-EXTI9_5
-EXTI15_10
-EXTI7_0
-EXTI15_8
-EXTI25_16
-*/
+#[cfg(feature = "exti")]
+pub use exti_inner::*;
 
-/// safety: must be called only once
-#[cfg(gpio_x0)]
-mod irq_impl {
-    use super::*;
+#[cfg(feature = "exti")]
+pub(crate) use exti_inner::init;
 
-    #[interrupt]
-    unsafe fn EXTI7_0() {
-        on_irq();
-    }
-    #[interrupt]
-    unsafe fn EXTI15_8() {
-        on_irq();
-    }
-    #[interrupt]
-    unsafe fn EXTI25_16() {
-        on_irq();
+#[cfg(feature = "exti")]
+mod exti_inner {
+    use core::future::Future;
+    use core::marker::PhantomData;
+    use core::pin::Pin;
+    use core::task::{Context, Poll};
+
+    use embassy_sync::waitqueue::AtomicWaker;
+    use qingke_rt::interrupt;
+
+    use super::Channel;
+    use crate::gpio::{AnyPin, Input, Level, Pin as GpioPin, Pull};
+    use crate::Peri;
+
+    const EXTI_COUNT: usize = 24;
+    const NEW_AW: AtomicWaker = AtomicWaker::new();
+    static EXTI_WAKERS: [AtomicWaker; EXTI_COUNT] = [NEW_AW; EXTI_COUNT];
+
+    pub unsafe fn on_irq() {
+        let exti = &crate::pac::EXTI;
+
+        let bits = exti.intfr().read();
+
+        // We don't handle or change any EXTI lines above 24.
+        let bits = bits.0 & 0x00FFFFFF;
+
+        // Clear pending - Clears the EXTI's line pending bits.
+        exti.intfr().write(|w| w.0 = bits);
+
+        exti.intenr().modify(|w| w.0 = w.0 & !bits);
+
+        // Wake the tasks
+        for pin in BitIter(bits) {
+            EXTI_WAKERS[pin as usize].wake();
+        }
     }
 
-    pub(crate) unsafe fn init(_cs: critical_section::CriticalSection) {
-        use crate::pac::Interrupt;
+    struct BitIter(u32);
 
-        qingke::pfic::enable_interrupt(Interrupt::EXTI7_0 as u8);
-        qingke::pfic::enable_interrupt(Interrupt::EXTI15_8 as u8);
-        qingke::pfic::enable_interrupt(Interrupt::EXTI25_16 as u8);
+    impl Iterator for BitIter {
+        type Item = u32;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            match self.0.trailing_zeros() {
+                32 => None,
+                b => {
+                    self.0 &= !(1 << b);
+                    Some(b)
+                }
+            }
+        }
     }
+
+    /// EXTI input driver
+    pub struct ExtiInput<'d> {
+        pin: Input<'d>,
+    }
+
+    impl<'d> Unpin for ExtiInput<'d> {}
+
+    impl<'d> ExtiInput<'d> {
+        pub fn new<T: GpioPin>(
+            pin: Peri<'d, T>,
+            ch: Peri<'d, T::ExtiChannel>,
+            pull: Pull,
+        ) -> Self {
+            // Needed if using AnyPin+AnyChannel.
+            assert_eq!(pin.pin(), ch.number());
+
+            Self {
+                pin: Input::new(pin, pull),
+            }
+        }
+
+        pub fn is_high(&self) -> bool {
+            self.pin.is_high()
+        }
+
+        pub fn is_low(&self) -> bool {
+            self.pin.is_low()
+        }
+
+        pub fn get_level(&self) -> Level {
+            self.pin.get_level()
+        }
+
+        pub async fn wait_for_high<'a>(&'a mut self) {
+            let fut = ExtiInputFuture::new(self.pin.pin.pin.pin(), self.pin.pin.pin.port(), true, false);
+            if self.is_high() {
+                return;
+            }
+            fut.await
+        }
+
+        pub async fn wait_for_low<'a>(&'a mut self) {
+            let fut = ExtiInputFuture::new(self.pin.pin.pin.pin(), self.pin.pin.pin.port(), false, true);
+            if self.is_low() {
+                return;
+            }
+            fut.await
+        }
+
+        pub async fn wait_for_rising_edge<'a>(&'a mut self) {
+            ExtiInputFuture::new(self.pin.pin.pin.pin(), self.pin.pin.pin.port(), true, false).await
+        }
+
+        pub async fn wait_for_falling_edge<'a>(&'a mut self) {
+            ExtiInputFuture::new(self.pin.pin.pin.pin(), self.pin.pin.pin.port(), false, true).await
+        }
+
+        pub async fn wait_for_any_edge<'a>(&'a mut self) {
+            ExtiInputFuture::new(self.pin.pin.pin.pin(), self.pin.pin.pin.port(), true, true).await
+        }
+    }
+
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    struct ExtiInputFuture<'a> {
+        pin: u8,
+        phantom: PhantomData<&'a mut AnyPin>,
+    }
+
+    // EXTI0-EXTI23 Px0-Px23（x=A/B/C）
+    impl<'a> ExtiInputFuture<'a> {
+        fn new(pin: u8, port: u8, rising: bool, falling: bool) -> Self {
+            critical_section::with(|_| {
+                let exti = &crate::pac::EXTI;
+                let afio = &crate::pac::AFIO;
+
+                let port = port as u8;
+                let pin = pin as usize;
+
+                #[cfg(any(afio_v003, afio_v00x))]
+                {
+                    // AFIO_EXTICR
+                    // stride: 2, len: 15, 8 lines
+                    afio.exticr().modify(|w| w.set_exti(pin, port));
+                }
+                // V1, V2, V3, L1
+                #[cfg(any(afio_v3, afio_l1))]
+                {
+                    // AFIO_EXTICRx
+                    // stride: 4, len: 4, 16 lines
+                    afio.exticr(pin / 4).modify(|w| w.set_exti(pin % 4, port));
+                }
+                #[cfg(afio_x0)]
+                {
+                    // stride: 2, len: 15, 24 lines
+                    afio.exticr(pin / 16).modify(|w| w.set_exti(pin % 16, port));
+                }
+                #[cfg(afio_ch641)]
+                {
+                    // single register
+                    afio.exticr().modify(|w| w.set_exti(pin, port != 0));
+                }
+
+                // See-also: 7.4.3
+                exti.intenr().modify(|w| w.set_mr(pin, true)); // enable interrupt
+
+                exti.rtenr().modify(|w| w.set_tr(pin, rising));
+                exti.ftenr().modify(|w| w.set_tr(pin, falling));
+            });
+
+            Self {
+                pin,
+                phantom: PhantomData,
+            }
+        }
+    }
+
+    impl<'a> Drop for ExtiInputFuture<'a> {
+        fn drop(&mut self) {
+            critical_section::with(|_| {
+                let exti = &crate::pac::EXTI;
+                let pin = self.pin;
+                exti.intenr().modify(|w| w.0 = w.0 & !(1 << pin));
+            });
+        }
+    }
+
+    impl<'a> Future for ExtiInputFuture<'a> {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let exti = &crate::pac::EXTI;
+
+            EXTI_WAKERS[self.pin as usize].register(cx.waker());
+
+            if exti.intenr().read().mr(self.pin as _) == false {
+                // intenr cleared by on_irq, then we can assume it is triggered
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        }
+    }
+
+    /*
+    EXTI0
+    EXTI1
+    EXTI2
+    EXTI3
+    EXTI4
+    EXTI9_5
+    EXTI15_10
+    EXTI7_0
+    EXTI15_8
+    EXTI25_16
+    */
+
+    /// safety: must be called only once
+    #[cfg(gpio_x0)]
+    mod irq_impl {
+        use super::*;
+
+        #[interrupt]
+        unsafe fn EXTI7_0() {
+            on_irq();
+        }
+        #[interrupt]
+        unsafe fn EXTI15_8() {
+            on_irq();
+        }
+        #[interrupt]
+        unsafe fn EXTI25_16() {
+            on_irq();
+        }
+
+        pub(crate) unsafe fn init(_cs: critical_section::CriticalSection) {
+            use crate::pac::Interrupt;
+
+            qingke::pfic::enable_interrupt(Interrupt::EXTI7_0 as u8);
+            qingke::pfic::enable_interrupt(Interrupt::EXTI15_8 as u8);
+            qingke::pfic::enable_interrupt(Interrupt::EXTI25_16 as u8);
+        }
+    }
+
+    #[cfg(all(gpio_v3, not(ch641)))]
+    mod irq_impl {
+        use super::*;
+
+        #[interrupt]
+        unsafe fn EXTI0() {
+            on_irq();
+        }
+        #[interrupt]
+        unsafe fn EXTI1() {
+            on_irq();
+        }
+        #[interrupt]
+        unsafe fn EXTI2() {
+            on_irq();
+        }
+        #[interrupt]
+        unsafe fn EXTI3() {
+            on_irq();
+        }
+        #[interrupt]
+        unsafe fn EXTI4() {
+            on_irq();
+        }
+        #[interrupt]
+        unsafe fn EXTI9_5() {
+            on_irq();
+        }
+        #[interrupt]
+        unsafe fn EXTI15_10() {
+            on_irq();
+        }
+
+        pub(crate) unsafe fn init(_cs: critical_section::CriticalSection) {
+            use crate::pac::Interrupt;
+
+            qingke::pfic::enable_interrupt(Interrupt::EXTI0 as u8);
+            qingke::pfic::enable_interrupt(Interrupt::EXTI1 as u8);
+            qingke::pfic::enable_interrupt(Interrupt::EXTI2 as u8);
+            qingke::pfic::enable_interrupt(Interrupt::EXTI3 as u8);
+            qingke::pfic::enable_interrupt(Interrupt::EXTI4 as u8);
+            qingke::pfic::enable_interrupt(Interrupt::EXTI9_5 as u8);
+            qingke::pfic::enable_interrupt(Interrupt::EXTI15_10 as u8);
+        }
+    }
+
+    #[cfg(gpio_v0)]
+    mod irq_impl {
+        use super::*;
+
+        #[interrupt]
+        unsafe fn EXTI7_0() {
+            on_irq();
+        }
+
+        pub(crate) unsafe fn init(_cs: critical_section::CriticalSection) {
+            use crate::pac::Interrupt;
+
+            qingke::pfic::enable_interrupt(Interrupt::EXTI7_0 as u8);
+        }
+    }
+
+    #[cfg(all(gpio_v3, ch641))]
+    mod irq_impl {
+        use super::*;
+
+        #[interrupt]
+        unsafe fn EXTI7_0() {
+            on_irq();
+        }
+
+        #[interrupt]
+        unsafe fn EXTI15_8() {
+            on_irq();
+        }
+
+        pub(crate) unsafe fn init(_cs: critical_section::CriticalSection) {
+            use crate::pac::Interrupt;
+
+            qingke::pfic::enable_interrupt(Interrupt::EXTI7_0 as u8);
+            qingke::pfic::enable_interrupt(Interrupt::EXTI15_8 as u8);
+        }
+    }
+
+    pub(crate) use irq_impl::init;
 }
-
-#[cfg(all(gpio_v3, not(ch641)))]
-mod irq_impl {
-    use super::*;
-
-    #[interrupt]
-    unsafe fn EXTI0() {
-        on_irq();
-    }
-    #[interrupt]
-    unsafe fn EXTI1() {
-        on_irq();
-    }
-    #[interrupt]
-    unsafe fn EXTI2() {
-        on_irq();
-    }
-    #[interrupt]
-    unsafe fn EXTI3() {
-        on_irq();
-    }
-    #[interrupt]
-    unsafe fn EXTI4() {
-        on_irq();
-    }
-    #[interrupt]
-    unsafe fn EXTI9_5() {
-        on_irq();
-    }
-    #[interrupt]
-    unsafe fn EXTI15_10() {
-        on_irq();
-    }
-
-    pub(crate) unsafe fn init(_cs: critical_section::CriticalSection) {
-        use crate::pac::Interrupt;
-
-        qingke::pfic::enable_interrupt(Interrupt::EXTI0 as u8);
-        qingke::pfic::enable_interrupt(Interrupt::EXTI1 as u8);
-        qingke::pfic::enable_interrupt(Interrupt::EXTI2 as u8);
-        qingke::pfic::enable_interrupt(Interrupt::EXTI3 as u8);
-        qingke::pfic::enable_interrupt(Interrupt::EXTI4 as u8);
-        qingke::pfic::enable_interrupt(Interrupt::EXTI9_5 as u8);
-        qingke::pfic::enable_interrupt(Interrupt::EXTI15_10 as u8);
-    }
-}
-
-#[cfg(gpio_v0)]
-mod irq_impl {
-    use super::*;
-
-    #[interrupt]
-    unsafe fn EXTI7_0() {
-        on_irq();
-    }
-
-    pub(crate) unsafe fn init(_cs: critical_section::CriticalSection) {
-        use crate::pac::Interrupt;
-
-        qingke::pfic::enable_interrupt(Interrupt::EXTI7_0 as u8);
-    }
-}
-
-#[cfg(all(gpio_v3, ch641))]
-mod irq_impl {
-    use super::*;
-
-    #[interrupt]
-    unsafe fn EXTI7_0() {
-        on_irq();
-    }
-
-    #[interrupt]
-    unsafe fn EXTI15_8() {
-        on_irq();
-    }
-
-    pub(crate) unsafe fn init(_cs: critical_section::CriticalSection) {
-        use crate::pac::Interrupt;
-
-        qingke::pfic::enable_interrupt(Interrupt::EXTI7_0 as u8);
-        qingke::pfic::enable_interrupt(Interrupt::EXTI15_8 as u8);
-    }
-}
-
-pub(crate) use irq_impl::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,7 @@ pub fn init(config: Config) -> Peripherals {
     ::critical_section::with(|cs| unsafe {
         gpio::init(cs);
         dma::init(cs, config.dma_interrupt_priority);
+        #[cfg(feature = "exti")]
         exti::init(cs);
     });
 


### PR DESCRIPTION
## Summary
- Adds an `exti` cargo feature (default-on) so users can disable the HAL's built-in EXTI driver and `#[interrupt]` handlers in order to install their own.
- No breaking change for existing users — feature is enabled by default.
- Rebases #111 onto current `main`. Original author: @MindsHubTeam (preserved as commit `Author`).

## What's gated
Moved into `#[cfg(feature = "exti")] mod exti_inner`:
- `ExtiInput`, `ExtiInputFuture`, `on_irq`
- All `irq_impl` modules (the `#[interrupt]` handlers and `init`)
- Private statics: `EXTI_WAKERS`, `BitIter`, `EXTI_COUNT`, `NEW_AW`

Kept always-available so user-written handlers can still name peripherals:
- `Channel` / `AnyChannel` traits
- `peripherals::EXTI0`..`EXTI23` impls

## Differences from #111
- Adapted to the current API: `Peri<'d, T>` (replaces `into_ref!`/`Peripheral`), `any(afio_v003, afio_v00x)` (replaces `afio_v0`), `PeripheralType` bound on `Channel`.
- Driver-internal statics moved inside the gated module (PR #111 left them at module top level, where they'd be dead code with the feature off).

Closes #111.

## Test plan
- [x] `cargo check` ch32v307 example (default features) — builds
- [x] `cargo check` ch32v307 `exti` example — builds
- [x] `cargo check` ch32x035 `exti` example (afio_x0 path) — builds
- [x] `cargo check` ch32v003 example (afio_v003 path) — builds
- [x] `cargo check` ch32v307 with `default-features = false` — lib builds; `hal::exti::ExtiInput` correctly absent
- [x] Smoke test on hardware (EXTI button wakeup) — not run

🤖 Generated with [Claude Code](https://claude.com/claude-code)