### PR TITLE
build.rs: add DAC channels to DMA peripheral map

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -471,6 +471,8 @@ fn main() {
         (("timer", "CH3"), quote!(crate::timer::Ch3Dma)),
         (("timer", "CH4"), quote!(crate::timer::Ch4Dma)),
         (("sdio", "SDIO"), quote!(crate::sdio::SdioDma)),
+        (("dac", "CH1"), quote!(crate::dac::DacDma1)),
+        (("dac", "CH2"), quote!(crate::dac::DacDma2)),
     ]
     .into();
 


### PR DESCRIPTION
## Summary
- Adds `dac` CH1/CH2 entries to the peripheral-to-DMA trait mapping table in `build.rs`, so the build script actually generates the `impl DacDma1 / DacDma2` lines that the DAC driver already expects (`src/dac.rs:230-231`, `src/dac.rs:346-347`).
- Without this, no chip got the trait impls generated, so async/DMA-driven DAC writes were unusable in practice.
- Rebase of #121 onto current `main`. Original author: @Usioumeo (preserved as commit `Author`).

## Test plan
- [x] `cargo check` on ch32v307 example (chip with DAC + DMA) — builds clean

Closes #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)