### PR TITLE
Updated embassy-executor, -time, -future and -sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,11 @@ embedded-can = "0.4.1"
 critical-section = { version = "1.2.0" }
 defmt = { version = "0.3.8", optional = true }
 
-embassy-sync = { version = "0.7.2" }
-embassy-futures = { version = "0.1.1" }
+embassy-sync = { version = "0.8.0" }
+embassy-futures = { version = "0.1.2" }
 embassy-time-queue-utils = { version = "0.3.0", optional = true }
 embassy-time-driver = { version = "0.2.0", optional = true }
-embassy-time = { version = "0.5.0", optional = true }
+embassy-time = { version = "0.5.1", optional = true }
 embassy-usb-driver = "0.2.0"
 embassy-net-driver = "0.2.0"
 embassy-net-driver-channel = "0.4.0"

--- a/examples/ch32l103/Cargo.toml
+++ b/examples/ch32l103/Cargo.toml
@@ -11,11 +11,11 @@ ch32-hal = { path = "../../", features = [
     "rt",
     "time-driver-tim2",
 ], default-features = false }
-embassy-executor = { version = "0.9.1", features = [
-    "arch-spin",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-spin",
     "executor-thread",
 ] }
-embassy-time = "0.5.0"
+embassy-time = "0.5.1"
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "0.7"

--- a/examples/ch32l103/src/bin/blinky.rs
+++ b/examples/ch32l103/src/bin/blinky.rs
@@ -29,7 +29,7 @@ async fn main(spawner: Spawner) -> ! {
 
 
     // GPIO
-    spawner.spawn(blink(p.PB12.into(), 1000)).unwrap();
+    spawner.spawn(blink(p.PB12.into(), 1000).unwrap());
 
     loop {
         Timer::after_millis(2000).await;

--- a/examples/ch32l103/src/bin/blinky.rs
+++ b/examples/ch32l103/src/bin/blinky.rs
@@ -6,7 +6,7 @@
 use ch32_hal as hal;
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::println;
 use hal::Peri;
 

--- a/examples/ch32l103/src/bin/rcc.rs
+++ b/examples/ch32l103/src/bin/rcc.rs
@@ -5,8 +5,8 @@
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;
-use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use embassy_time::Timer;
+use hal::gpio::{Level, Output};
 use hal::{println, Config};
 
 #[embassy_executor::main(entry = "qingke_rt::entry")]

--- a/examples/ch32l103/src/bin/usbpd.rs
+++ b/examples/ch32l103/src/bin/usbpd.rs
@@ -8,7 +8,7 @@ use ch32_hal::{bind_interrupts, peripherals};
 use embassy_executor::Spawner;
 use embassy_time::Timer;
 use panic_halt as _;
-use usbpd::protocol_layer::message::data::request::{self, CurrentRequest, VoltageRequest};
+use usbpd::protocol_layer::message::data::request::{self};
 use usbpd::protocol_layer::message::data::source_capabilities::SourceCapabilities;
 use usbpd::sink::device_policy_manager::{DevicePolicyManager, Event};
 use usbpd::sink::policy_engine::Sink;
@@ -136,7 +136,7 @@ async fn main(_spawner: Spawner) {
     config.rcc = hal::rcc::Config::SYSCLK_FREQ_96MHZ_HSE;
     let p = hal::init(config);
 
-    let mut phy = UsbPdPhy::new_async(p.USBPD, p.PB6, p.PB7, Irq);
+    let phy = UsbPdPhy::new_async(p.USBPD, p.PB6, p.PB7, Irq);
     phy.detect_cc().unwrap();
 
     let device = Device {};

--- a/examples/ch32v003/Cargo.toml
+++ b/examples/ch32v003/Cargo.toml
@@ -11,13 +11,13 @@ ch32-hal = { path = "../../", features = [
     "time-driver-tim2",
     "rt",
 ] }
-embassy-embedded-hal = "0.5.0"
-embassy-executor = { version = "0.9.1", features = [
-    "arch-spin",
+embassy-embedded-hal = "0.6.0"
+embassy-executor = { version = "0.10.0", features = [
+    "platform-spin",
     "executor-thread",
 ] }
-embassy-sync = "0.7.2"
-embassy-time = "0.5.0"
+embassy-sync = "0.8.0"
+embassy-time = "0.5.1"
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "0.7"

--- a/examples/ch32v003/src/bin/embassy_blinky.rs
+++ b/examples/ch32v003/src/bin/embassy_blinky.rs
@@ -7,7 +7,7 @@ use ch32_hal as hal;
 use hal::Peri;
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::println;
 
 #[embassy_executor::task(pool_size = 2)]

--- a/examples/ch32v003/src/bin/embassy_blinky.rs
+++ b/examples/ch32v003/src/bin/embassy_blinky.rs
@@ -34,8 +34,8 @@ async fn main(spawner: Spawner) -> ! {
 
     // let mut led = Output::new(p.PC4, Level::Low, Default::default());
 
-    spawner.spawn(blink(p.PD6.into(), 110)).unwrap();
-    spawner.spawn(blink(p.PA2.into(), 270)).unwrap();
+    spawner.spawn(blink(p.PD6.into(), 110).unwrap());
+    spawner.spawn(blink(p.PA2.into(), 270).unwrap());
 
     loop {
         Timer::after_millis(1000).await;

--- a/examples/ch32v003/src/bin/spi-lcd-st7735-cube.rs
+++ b/examples/ch32v003/src/bin/spi-lcd-st7735-cube.rs
@@ -12,10 +12,10 @@ use embedded_graphics::pixelcolor::raw::ToBytes;
 use embedded_graphics::pixelcolor::Rgb565;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Line, PrimitiveStyle};
-use hal::gpio::{Level, Output, Pin};
+use hal::gpio::{Level, Output};
 use hal::prelude::*;
 use hal::spi::Spi;
-use hal::{peripherals, println};
+use hal::peripherals;
 use micromath::F32Ext;
 use qingke::riscv;
 
@@ -436,7 +436,7 @@ fn main() -> ! {
 }
 
 #[panic_handler]
-fn panic(info: &core::panic::PanicInfo) -> ! {
+fn panic(_info: &core::panic::PanicInfo) -> ! {
     // CH32V003 is so resource constrained, adding strings is a bad idea.
     // let _ = println!("\n\n\n{}", info);
 

--- a/examples/ch32v003/src/bin/uart_tx.rs
+++ b/examples/ch32v003/src/bin/uart_tx.rs
@@ -20,7 +20,7 @@ fn main() -> ! {
 
     println!("dev init ok");
 
-    uart.blocking_write(b"Hello, world!\r\n").unwrap();
+    let _ = uart.blocking_write(b"Hello, world!\r\n").unwrap();
 
     let mut delay = Delay;
 
@@ -28,7 +28,7 @@ fn main() -> ! {
     loop {
         led.toggle();
 
-        uart.blocking_write(b"Hello, world!\r\n").unwrap();
+        let _ = uart.blocking_write(b"Hello, world!\r\n").unwrap();
 
         delay.delay_ms(1000);
     }

--- a/examples/ch32v006/Cargo.toml
+++ b/examples/ch32v006/Cargo.toml
@@ -11,11 +11,11 @@ ch32-hal = { path = "../../", features = [
     "time-driver-tim2",
     "rt",
 ] }
-embassy-executor = { version = "0.9.1", features = [
-    "arch-spin",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-spin",
     "executor-thread",
 ] }
-embassy-time = "0.5.0"
+embassy-time = "0.5.1"
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke = "0.7"

--- a/examples/ch32v006/src/bin/embassy_blinky.rs
+++ b/examples/ch32v006/src/bin/embassy_blinky.rs
@@ -30,8 +30,8 @@ async fn main(spawner: Spawner) -> ! {
     println!("CHIP signature => {}", hal::signature::chip_id().name());
     println!("Clocks {:?}", hal::rcc::clocks());
 
-    spawner.spawn(blink(p.PD6.into(), 110)).unwrap();
-    spawner.spawn(blink(p.PA4.into(), 270)).unwrap();
+    spawner.spawn(blink(p.PD6.into(), 110).unwrap());
+    spawner.spawn(blink(p.PA4.into(), 270).unwrap());
 
     loop {
         Timer::after_millis(1000).await;

--- a/examples/ch32v006/src/bin/uart_tx.rs
+++ b/examples/ch32v006/src/bin/uart_tx.rs
@@ -19,7 +19,7 @@ fn main() -> ! {
 
     println!("dev init ok");
 
-    uart.blocking_write(b"Hello, world!\r\n").unwrap();
+    let _ = uart.blocking_write(b"Hello, world!\r\n").unwrap();
 
     let mut delay = Delay;
 
@@ -27,7 +27,7 @@ fn main() -> ! {
     loop {
         led.toggle();
 
-        uart.blocking_write(b"Hello, world!\r\n").unwrap();
+        let _ = uart.blocking_write(b"Hello, world!\r\n").unwrap();
 
         delay.delay_ms(1000);
     }

--- a/examples/ch32v103/Cargo.toml
+++ b/examples/ch32v103/Cargo.toml
@@ -10,11 +10,11 @@ ch32-hal = { path = "../../", features = [
     "rt",
     "time-driver-tim2",
 ] }
-embassy-executor = { version = "0.9.1", features = [
-    "arch-spin",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-spin",
     "executor-thread",
 ] }
-embassy-time = "0.5.0"
+embassy-time = "0.5.1"
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke-rt = "0.7"

--- a/examples/ch32v103/src/bin/blinky.rs
+++ b/examples/ch32v103/src/bin/blinky.rs
@@ -5,7 +5,6 @@
 
 use ch32_hal as hal;
 use hal::gpio::{Level, Output};
-use hal::println;
 use qingke::riscv;
 
 #[qingke_rt::entry]
@@ -23,7 +22,7 @@ fn main() -> ! {
 }
 
 #[panic_handler]
-fn panic(info: &core::panic::PanicInfo) -> ! {
+fn panic(_info: &core::panic::PanicInfo) -> ! {
     // let _ = println!("\n\n\n{}", info);
 
     loop {}

--- a/examples/ch32v203/Cargo.toml
+++ b/examples/ch32v203/Cargo.toml
@@ -17,15 +17,15 @@ ch32-hal = { path = "../../", features = [
     "time-driver-tim2",
 ], default-features = false }
 
-embassy-executor = { version = "0.9.1", features = [
-    "arch-spin",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-spin",
     "executor-thread",
 ] }
 
-embassy-time = "0.5.0"
+embassy-time = "0.5.1"
 embassy-usb = { version = "0.5.1" }
 embassy-usb-driver = "=0.2.0"
-embassy-futures = { version = "0.1.0" }
+embassy-futures = { version = "0.1.2" }
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke-rt = "0.7"

--- a/examples/ch32v203/src/bin/adc.rs
+++ b/examples/ch32v203/src/bin/adc.rs
@@ -5,19 +5,17 @@
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;
-use embassy_time::{Delay, Duration, Timer};
+use embassy_time::{Duration, Timer};
 use hal::adc::{SampleTime, Pga};
 use hal::gpio::{Level, Output};
 use hal::println;
 
 #[embassy_executor::main(entry = "qingke_rt::entry")]
-async fn main(spawner: Spawner) -> ! {
+async fn main(_spawner: Spawner) -> ! {
     hal::debug::SDIPrint::enable();
     let mut config = hal::Config::default();
     config.rcc = hal::rcc::Config::SYSCLK_FREQ_96MHZ_HSI;
     let p = hal::init(config);
-
-    let mut delay = Delay;
 
     let mut adc = hal::adc::Adc::new(p.ADC1, Default::default());
 

--- a/examples/ch32v203/src/bin/flash_sections.rs
+++ b/examples/ch32v203/src/bin/flash_sections.rs
@@ -35,7 +35,7 @@ async fn main(spawner: Spawner) -> ! {
     let p = hal::init(config);
 
     // GPIO
-    spawner.spawn(blink(p.PB8.into(), 500)).unwrap();
+    spawner.spawn(blink(p.PB8.into(), 500).unwrap());
     let mut last = pac::SYSTICK.cnt().read();
     loop {
         Timer::after_millis(1000).await;

--- a/examples/ch32v203/src/bin/flash_sections.rs
+++ b/examples/ch32v203/src/bin/flash_sections.rs
@@ -7,7 +7,7 @@ use ch32_hal as hal;
 use hal::Peri;
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::{pac, println};
 
 #[embassy_executor::task(pool_size = 3)]

--- a/examples/ch32v203/src/bin/spi-lcd-st7735.rs
+++ b/examples/ch32v203/src/bin/spi-lcd-st7735.rs
@@ -295,7 +295,7 @@ async fn main(spawner: Spawner) -> ! {
     println!("display init ok");
 
     // GPIO, // T1C4
-    spawner.spawn(blink(led.into())).unwrap();
+    spawner.spawn(blink(led.into()).unwrap());
 
     display.clear(Rgb565::BLACK).unwrap();
 

--- a/examples/ch32v203/src/bin/spi-lcd-st7735.rs
+++ b/examples/ch32v203/src/bin/spi-lcd-st7735.rs
@@ -22,7 +22,7 @@ use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Line, PrimitiveStyle};
 use embedded_graphics::text::{Alignment, Text};
 use embedded_hal::delay::DelayNs;
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::prelude::*;
 use hal::spi::Spi;
 use hal::{peripherals, println, Peri};

--- a/examples/ch32v203/src/bin/uart.rs
+++ b/examples/ch32v203/src/bin/uart.rs
@@ -5,24 +5,24 @@
 
 use ch32_hal::usart;
 use embassy_executor::Spawner;
-use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use embassy_time::Timer;
+use hal::gpio::{Level, Output};
 use hal::usart::UartTx;
 use {ch32_hal as hal, panic_halt as _};
 
 #[embassy_executor::main(entry = "qingke_rt::entry")]
-async fn main(spawner: Spawner) -> ! {
+async fn main(_spawner: Spawner) -> ! {
     let p = hal::init(Default::default());
 
     let mut led = Output::new(p.PB8, Level::Low, Default::default());
 
-    let mut cfg = usart::Config::default();
+    let cfg = usart::Config::default();
     let mut uart = UartTx::new_blocking(p.USART1, p.PA9, cfg).unwrap();
 
     loop {
         Timer::after_millis(1000).await;
 
-        uart.blocking_write(b"hello world from embassy main\r\n");
+        let _ = uart.blocking_write(b"hello world from embassy main\r\n");
 
         led.toggle();
     }

--- a/examples/ch32v208/Cargo.toml
+++ b/examples/ch32v208/Cargo.toml
@@ -10,11 +10,11 @@ ch32-hal = { path = "../../", features = [
     "embassy",
     "rt",
 ], default-features = false }
-embassy-executor = { version = "0.9.1", features = [
-    "arch-spin",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-spin",
     "executor-thread",
 ] }
-embassy-time = "0.5.0"
+embassy-time = "0.5.1"
 
 # This is okay because we should automatically use whatever ch32-hal uses
 qingke-rt = "0.7"
@@ -29,7 +29,7 @@ static_cell = "2.1"
 embedded-io-async = "0.7"
 portable-atomic = { version = "1", features = ["critical-section"] }
 
-embassy-futures = "0.1.1"
+embassy-futures = "0.1.2"
 heapless = "0.8.0"
 
 [profile.release]

--- a/examples/ch32v208/src/bin/embassy_blinky.rs
+++ b/examples/ch32v208/src/bin/embassy_blinky.rs
@@ -32,8 +32,8 @@ async fn main(spawner: Spawner) -> ! {
     println!("Clocks: {:?}", hal::rcc::clocks());
 
     // Spawn blink tasks with different intervals
-    spawner.spawn(blink(p.PB8.into(), 500)).unwrap();
-    spawner.spawn(blink(p.PB9.into(), 200)).unwrap();
+    spawner.spawn(blink(p.PB8.into(), 500).unwrap());
+    spawner.spawn(blink(p.PB9.into(), 200).unwrap());
 
     let mut tick = 0u32;
     loop {

--- a/examples/ch32v208/src/bin/eth.rs
+++ b/examples/ch32v208/src/bin/eth.rs
@@ -71,8 +71,8 @@ async fn main(spawner: Spawner) -> ! {
     let config = embassy_net::Config::dhcpv4(Default::default());
     let (stack, net_runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    spawner.spawn(ethernet_task(runner)).unwrap();
-    spawner.spawn(net_task(net_runner)).unwrap();
+    spawner.spawn(ethernet_task(runner).unwrap());
+    spawner.spawn(net_task(net_runner).unwrap());
 
     println!("Waiting for DHCP...");
     stack.wait_config_up().await;

--- a/examples/ch32v208/src/bin/eth_echo.rs
+++ b/examples/ch32v208/src/bin/eth_echo.rs
@@ -77,8 +77,8 @@ async fn main(spawner: Spawner) -> ! {
     let config = embassy_net::Config::dhcpv4(Default::default());
     let (stack, net_runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    spawner.spawn(ethernet_task(runner)).unwrap();
-    spawner.spawn(net_task(net_runner)).unwrap();
+    spawner.spawn(ethernet_task(runner).unwrap());
+    spawner.spawn(net_task(net_runner).unwrap());
 
     println!("Waiting for DHCP...");
     stack.wait_config_up().await;

--- a/examples/ch32v305/Cargo.toml
+++ b/examples/ch32v305/Cargo.toml
@@ -10,11 +10,11 @@ ch32-hal = { path = "../../", features = [
     "embassy",
     "rt",
 ] }
-embassy-executor = { version = "0.9.1", features = [
-    "arch-spin",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-spin",
     "executor-thread",
 ] }
-embassy-time = "0.5.0"
+embassy-time = "0.5.1"
 
 qingke-rt = "0.7"
 qingke = "0.7"

--- a/examples/ch32v305/src/bin/adc.rs
+++ b/examples/ch32v305/src/bin/adc.rs
@@ -5,18 +5,16 @@
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;
-use embassy_time::{Delay, Duration, Timer};
+use embassy_time::{Duration, Timer};
 use hal::adc::{SampleTime, Pga};
 use hal::gpio::{Level, Output};
 use hal::println;
 
 #[embassy_executor::main(entry = "qingke_rt::entry")]
-async fn main(spawner: Spawner) -> ! {
+async fn main(_spawner: Spawner) -> ! {
     hal::debug::SDIPrint::enable();
-    let mut config = hal::Config::default();
+    let config = hal::Config::default();
     let p = hal::init(config);
-
-    let mut delay = Delay;
 
     let mut adc = hal::adc::Adc::new(p.ADC1, Default::default());
 

--- a/examples/ch32v305/src/bin/blinky.rs
+++ b/examples/ch32v305/src/bin/blinky.rs
@@ -26,8 +26,8 @@ async fn main(spawner: Spawner) -> ! {
     let p = hal::init(Default::default());
 
     // GPIO
-    spawner.spawn(blink(p.PC9.into(), 400)).unwrap();
-    // spawner.spawn(blink(p.PB8.into(), 100)).unwrap();
+    spawner.spawn(blink(p.PC9.into(), 400).unwrap());
+    // spawner.spawn(blink(p.PB8.into(), 100).unwrap());
     loop {
         Timer::after_millis(2000).await;
     }

--- a/examples/ch32v305/src/bin/blinky.rs
+++ b/examples/ch32v305/src/bin/blinky.rs
@@ -5,7 +5,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::Peri;
 use {ch32_hal as hal, panic_halt as _};
 

--- a/examples/ch32v305/src/bin/demo.rs
+++ b/examples/ch32v305/src/bin/demo.rs
@@ -35,7 +35,7 @@ async fn main(spawner: Spawner) -> ! {
     let p = hal::init(config);
 
     // GPIO
-    spawner.spawn(blink(p.PA15.into(), 500)).unwrap();
+    spawner.spawn(blink(p.PA15.into(), 500).unwrap());
     let mut last = pac::SYSTICK.cnt().read();
     loop {
         Timer::after_millis(1000).await;

--- a/examples/ch32v305/src/bin/demo.rs
+++ b/examples/ch32v305/src/bin/demo.rs
@@ -7,7 +7,7 @@ use ch32_hal as hal;
 use hal::Peri;
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::{pac, println};
 
 #[embassy_executor::task(pool_size = 3)]

--- a/examples/ch32v305/src/bin/exti.rs
+++ b/examples/ch32v305/src/bin/exti.rs
@@ -8,7 +8,7 @@ use hal::Peri;
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use hal::exti::ExtiInput;
-use hal::gpio::{AnyPin, Level, Output, Pin, Pull, Speed};
+use hal::gpio::{AnyPin, Level, Output, Pull, Speed};
 use hal::println;
 
 #[embassy_executor::task]

--- a/examples/ch32v305/src/bin/exti.rs
+++ b/examples/ch32v305/src/bin/exti.rs
@@ -34,7 +34,7 @@ async fn main(spawner: Spawner) -> ! {
     ei.wait_for_falling_edge().await;
 
     // GPIO, PA8 and PC9 shares the same pin, use with caution
-    spawner.spawn(blink(p.PA8.into())).unwrap();
+    spawner.spawn(blink(p.PA8.into()).unwrap());
 
     loop {
         Timer::after(Duration::from_millis(1000)).await;

--- a/examples/ch32v305/src/bin/i2c.rs
+++ b/examples/ch32v305/src/bin/i2c.rs
@@ -8,7 +8,6 @@ use embassy_executor::Spawner;
 use embassy_time::Timer;
 use hal::gpio::{Level, Output};
 use hal::i2c::I2c;
-use hal::mode::Blocking;
 use hal::println;
 use hal::time::Hertz;
 
@@ -111,7 +110,7 @@ async fn main(spawner: Spawner) -> ! {
     let sda = p.PB11;
 
     // on APB1
-    let mut i2c_config = hal::i2c::Config::default();
+    let _i2c_config = hal::i2c::Config::default();
     //  i2c_config.scl_pullup = true;
     //i2c_config.sda_pullup = true;
     let mut i2c = I2c::new_blocking(p.I2C2, scl, sda, Hertz::hz(400_000), Default::default());

--- a/examples/ch32v305/src/bin/rcc.rs
+++ b/examples/ch32v305/src/bin/rcc.rs
@@ -54,9 +54,9 @@ async fn main(spawner: Spawner) -> ! {
     println!("PCLK2: {}Hz", hal::rcc::clocks().pclk2.0);
 
     // GPIO
-    spawner.spawn(blink(p.PC9.into(), 1000)).unwrap();
-    spawner.spawn(blink(p.PB4.into(), 100)).unwrap();
-    spawner.spawn(blink(p.PB8.into(), 100)).unwrap();
+    spawner.spawn(blink(p.PC9.into(), 1000).unwrap());
+    spawner.spawn(blink(p.PB4.into(), 100).unwrap());
+    spawner.spawn(blink(p.PB8.into(), 100).unwrap());
     let mut tick = 0;
     loop {
         Timer::after_millis(1000).await;

--- a/examples/ch32v305/src/bin/rcc.rs
+++ b/examples/ch32v305/src/bin/rcc.rs
@@ -5,7 +5,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::println;
 use hal::time::Hertz;
 use hal::Peri;

--- a/examples/ch32v305/src/bin/spi-lcd-st7735-cube.rs
+++ b/examples/ch32v305/src/bin/spi-lcd-st7735-cube.rs
@@ -15,11 +15,11 @@ use embedded_graphics::framebuffer::Framebuffer;
 use embedded_graphics::mono_font::ascii::FONT_9X18;
 use embedded_graphics::mono_font::MonoTextStyle;
 use embedded_graphics::pixelcolor::raw::{LittleEndian, ToBytes};
-use embedded_graphics::pixelcolor::{BinaryColor, Rgb565};
+use embedded_graphics::pixelcolor::Rgb565;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Line, PrimitiveStyle};
 use embedded_hal::delay::DelayNs;
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::prelude::*;
 use hal::spi::Spi;
 use hal::{peripherals, println};
@@ -380,7 +380,7 @@ async fn main(_spawner: Spawner) -> ! {
 
     let mut inc = true;
 
-    let mut text_style = MonoTextStyle::new(&FONT_9X18, Rgb565::CSS_TOMATO);
+    let _text_style = MonoTextStyle::new(&FONT_9X18, Rgb565::CSS_TOMATO);
 
     loop {
         for (i, [x, y, z]) in orig_points.iter().copied().enumerate() {

--- a/examples/ch32v305/src/bin/uart_echo.rs
+++ b/examples/ch32v305/src/bin/uart_echo.rs
@@ -4,14 +4,13 @@
 
 
 use embassy_executor::Spawner;
-use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
-use hal::usart::{Uart, UartTx};
-use hal::{println, usart};
+use hal::gpio::{Level, Output};
+use hal::usart::Uart;
+use hal::usart;
 use {ch32_hal as hal, panic_halt as _};
 
 #[embassy_executor::main(entry = "qingke_rt::entry")]
-async fn main(spawner: Spawner) -> ! {
+async fn main(_spawner: Spawner) -> ! {
     hal::debug::SDIPrint::enable();
     let p = hal::init(Default::default());
 
@@ -22,7 +21,7 @@ async fn main(spawner: Spawner) -> ! {
     cfg.baudrate = 115200;
     let mut uart = Uart::new_blocking(p.USART3, p.PB11, p.PB10, cfg).unwrap();
 
-    uart.blocking_write(b"Init ok\r\n");
+    let _ = uart.blocking_write(b"Init ok\r\n");
 
     // FIXME: no time slice for embassy executor
     let mut buf = [0u8; 1];
@@ -34,10 +33,10 @@ async fn main(spawner: Spawner) -> ! {
         }
 
         if buf[0] == b'\r' {
-            uart.blocking_write(b"\r\n").unwrap();
+            let _ = uart.blocking_write(b"\r\n").unwrap();
             led.toggle();
         } else {
-            uart.blocking_write(&buf).unwrap();
+            let _ = uart.blocking_write(&buf).unwrap();
         }
     }
 }

--- a/examples/ch32v305/src/bin/uart_tx.rs
+++ b/examples/ch32v305/src/bin/uart_tx.rs
@@ -6,7 +6,7 @@
 use ch32_hal::usart;
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::usart::UartTx;
 use hal::Peri;
 use {ch32_hal as hal, panic_halt as _};
@@ -36,6 +36,6 @@ async fn main(spawner: Spawner) -> ! {
     loop {
         Timer::after_millis(2000).await;
 
-        uart.blocking_write(b"hello world from embassy main\r\n").unwrap();
+        let _ = uart.blocking_write(b"hello world from embassy main\r\n").unwrap();
     }
 }

--- a/examples/ch32v305/src/bin/uart_tx.rs
+++ b/examples/ch32v305/src/bin/uart_tx.rs
@@ -28,7 +28,7 @@ async fn main(spawner: Spawner) -> ! {
     let p = hal::init(Default::default());
 
     // GPIO
-    spawner.spawn(blink(p.PC9.into())).unwrap();
+    spawner.spawn(blink(p.PC9.into()).unwrap());
 
     let cfg = usart::Config::default();
     let mut uart = UartTx::new_blocking(p.USART3, p.PB10, cfg).unwrap();

--- a/examples/ch32v307/Cargo.toml
+++ b/examples/ch32v307/Cargo.toml
@@ -10,16 +10,16 @@ ch32-hal = { path = "../../", features = [
     "embassy",
     "rt",
     "highcode",
-    "time-driver-tim1",
+    #"time-driver-tim1",
 ] }
-embassy-executor = { version = "0.9.1", features = [
-    "arch-spin",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-spin",
     "executor-thread",
 ] }
 
 critical-section = "1.2.0"
 
-embassy-time = "0.5.0"
+embassy-time = "0.5.1"
 embassy-usb = "0.5.1"
 embassy-usb-driver = "=0.2.0"
 embassy-futures = "0.1.2"

--- a/examples/ch32v307/src/bin/adc.rs
+++ b/examples/ch32v307/src/bin/adc.rs
@@ -5,19 +5,17 @@
 
 use ch32_hal as hal;
 use embassy_executor::Spawner;
-use embassy_time::{Delay, Duration, Timer};
+use embassy_time::{Duration, Timer};
 use hal::adc::{SampleTime, Pga};
 use hal::gpio::{Level, Output};
 use hal::println;
 
 #[embassy_executor::main(entry = "ch32_hal::entry")]
-async fn main(spawner: Spawner) -> ! {
+async fn main(_spawner: Spawner) -> ! {
     hal::debug::SDIPrint::enable();
     let mut config = hal::Config::default();
     config.rcc = hal::rcc::Config::SYSCLK_FREQ_96MHZ_HSI;
     let p = hal::init(config);
-
-    let delay = Delay;
 
     let mut adc = hal::adc::Adc::new(p.ADC1, Default::default());
 

--- a/examples/ch32v307/src/bin/blinky_pwm.rs
+++ b/examples/ch32v307/src/bin/blinky_pwm.rs
@@ -14,8 +14,6 @@ use {ch32_hal as hal, panic_halt as _};
 #[embassy_executor::main(entry = "ch32_hal::entry")]
 async fn main(_spawner: Spawner) -> ! {
     hal::debug::SDIPrint::enable();
-    let mut config = hal::Config::default();
-    config.rcc = hal::rcc::Config::SYSCLK_FREQ_144MHZ_HSE;
     let p = hal::init(Default::default());
 
     // use remap 1, or 3

--- a/examples/ch32v307/src/bin/button.rs
+++ b/examples/ch32v307/src/bin/button.rs
@@ -33,7 +33,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let led = Output::new(p.PA15, Level::Low, Speed::default());
 
-    spawner.spawn(blink(led)).unwrap();
+    spawner.spawn(blink(led).unwrap());
 
     loop {
         if button.is_low() {

--- a/examples/ch32v307/src/bin/embassy_blinky.rs
+++ b/examples/ch32v307/src/bin/embassy_blinky.rs
@@ -26,9 +26,9 @@ async fn main(spawner: Spawner) -> ! {
     let p = hal::init(Default::default());
 
     // GPIO
-    spawner.spawn(blink(p.PA15.into(), 1000)).unwrap();
-    spawner.spawn(blink(p.PB4.into(), 100)).unwrap();
-    // spawner.spawn(blink(p.PB8.into(), 100)).unwrap();
+    spawner.spawn(blink(p.PA15.into(), 1000).unwrap());
+    spawner.spawn(blink(p.PB4.into(), 100).unwrap());
+    // spawner.spawn(blink(p.PB8.into(), 100).unwrap());
     loop {
         Timer::after_millis(2000).await;
     }

--- a/examples/ch32v307/src/bin/embassy_blinky.rs
+++ b/examples/ch32v307/src/bin/embassy_blinky.rs
@@ -5,7 +5,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::Peri;
 use {ch32_hal as hal, panic_halt as _};
 

--- a/examples/ch32v307/src/bin/exti.rs
+++ b/examples/ch32v307/src/bin/exti.rs
@@ -34,7 +34,7 @@ async fn main(spawner: Spawner) -> ! {
     ei.wait_for_falling_edge().await;
 
     // GPIO
-    spawner.spawn(blink(p.PA15.into())).unwrap();
+    spawner.spawn(blink(p.PA15.into()).unwrap());
 
     loop {
         Timer::after(Duration::from_millis(1000)).await;

--- a/examples/ch32v307/src/bin/exti.rs
+++ b/examples/ch32v307/src/bin/exti.rs
@@ -8,7 +8,7 @@ use hal::Peri;
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use hal::exti::ExtiInput;
-use hal::gpio::{AnyPin, Level, Output, Pin, Pull, Speed};
+use hal::gpio::{AnyPin, Level, Output, Pull, Speed};
 use hal::println;
 
 #[embassy_executor::task]

--- a/examples/ch32v307/src/bin/flash.rs
+++ b/examples/ch32v307/src/bin/flash.rs
@@ -3,7 +3,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(impl_trait_in_assoc_type)]
 
-use ch32_hal::flash::{Flash, FLASH_BASE};
+use ch32_hal::flash::{Flash};
 use ch32_hal::rcc::*;
 use ch32_hal::{interrupt, println};
 use embassy_executor::Spawner;
@@ -41,11 +41,11 @@ async fn main(_spawner: Spawner) -> ! {
     Timer::after_millis(1000).await;
 
     let mut f = Flash::new_blocking(p.FLASH);
-    const size: u32 = 256;
+    const SIZE: u32 = 256;
     let start: u32 = 1024 * 32;
     let stop = start + 256 * 3;
-    for offset in (start..stop).step_by(size as usize) {
-        println!("Testing offset: {:#X}, size: {:#X}", offset, size);
+    for offset in (start..stop).step_by(SIZE as usize) {
+        println!("Testing offset: {:#X}, size: {:#X}", offset, SIZE);
 
         println!("Reading...");
         let mut buf = [0u8; 32];
@@ -53,7 +53,7 @@ async fn main(_spawner: Spawner) -> ! {
         println!("Read: {:?}", buf);
 
         println!("Erasing...");
-        println!("{:?}", f.blocking_erase(offset, offset + size));
+        println!("{:?}", f.blocking_erase(offset, offset + SIZE));
 
         println!("Reading...");
         let mut buf = [0u8; 32];
@@ -61,7 +61,7 @@ async fn main(_spawner: Spawner) -> ! {
         println!("Read after erase: {:?}", buf);
 
         println!("Writing...");
-        println!("{:?}", f.blocking_write(offset, &[0xabu8; size as usize]));
+        println!("{:?}", f.blocking_write(offset, &[0xabu8; SIZE as usize]));
 
         println!("Reading...");
         let mut buf = [0u8; 32];

--- a/examples/ch32v307/src/bin/flash.rs
+++ b/examples/ch32v307/src/bin/flash.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_assoc_type)]
 
 use ch32_hal::flash::{Flash};
 use ch32_hal::rcc::*;

--- a/examples/ch32v307/src/bin/i2c-bmp180-async.rs
+++ b/examples/ch32v307/src/bin/i2c-bmp180-async.rs
@@ -26,8 +26,6 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 #[embassy_executor::main(entry = "ch32_hal::entry")]
 async fn main(_spawner: Spawner) -> ! {
     hal::debug::SDIPrint::enable();
-    let mut config = hal::Config::default();
-    config.rcc = hal::rcc::Config::SYSCLK_FREQ_144MHZ_HSE;
     let p = hal::init(Default::default());
 
     let i2c_sda = p.PB11;

--- a/examples/ch32v307/src/bin/i2c-bmp180.rs
+++ b/examples/ch32v307/src/bin/i2c-bmp180.rs
@@ -19,8 +19,6 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 #[embassy_executor::main(entry = "ch32_hal::entry")]
 async fn main(_spawner: Spawner) -> ! {
     hal::debug::SDIPrint::enable();
-    let mut config = hal::Config::default();
-    config.rcc = hal::rcc::Config::SYSCLK_FREQ_144MHZ_HSE;
     let p = hal::init(Default::default());
 
     let i2c_sda = p.PB11;

--- a/examples/ch32v307/src/bin/i2c-eeprom.rs
+++ b/examples/ch32v307/src/bin/i2c-eeprom.rs
@@ -7,7 +7,7 @@ use ch32_hal as hal;
 use hal::Peri;
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin, Speed};
+use hal::gpio::{AnyPin, Level, Output, Speed};
 use hal::i2c::I2c;
 use hal::mode::Blocking;
 use hal::time::Hertz;
@@ -53,13 +53,11 @@ async fn main(spawner: Spawner) -> ! {
 
     println!("init ok");
 
-    let mut i2c = I2c::new_blocking(p.I2C2, i2c_scl, i2c_sda, Hertz::khz(100), Default::default());
+    let i2c = I2c::new_blocking(p.I2C2, i2c_scl, i2c_sda, Hertz::khz(100), Default::default());
 
     // 7-bit address
     const FT24C32A_ADDR: u8 = 0b1010_000;
     // 32Kbit -> 4KByte
-
-    let mut buf = [0u8; 2];
 
     let mut eeprom = EEPROM::new(i2c, FT24C32A_ADDR);
 

--- a/examples/ch32v307/src/bin/i2c-eeprom.rs
+++ b/examples/ch32v307/src/bin/i2c-eeprom.rs
@@ -66,7 +66,7 @@ async fn main(spawner: Spawner) -> ! {
     println!("init i2c ok");
 
     // GPIO
-    spawner.spawn(blink(p.PA15.into())).unwrap();
+    spawner.spawn(blink(p.PA15.into()).unwrap());
 
     for addr in 0..16 {
         eeprom.write_byte(addr, b'x').unwrap();

--- a/examples/ch32v307/src/bin/i2c-ssd1306.rs
+++ b/examples/ch32v307/src/bin/i2c-ssd1306.rs
@@ -38,8 +38,6 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 #[embassy_executor::main(entry = "ch32_hal::entry")]
 async fn main(_spawner: Spawner) -> ! {
     hal::debug::SDIPrint::enable();
-    let mut config = hal::Config::default();
-    config.rcc = hal::rcc::Config::SYSCLK_FREQ_144MHZ_HSE;
     let p = hal::init(Default::default());
 
     let i2c_sda = p.PB11;

--- a/examples/ch32v307/src/bin/rcc.rs
+++ b/examples/ch32v307/src/bin/rcc.rs
@@ -36,9 +36,9 @@ async fn main(spawner: Spawner) -> ! {
     println!("PCLK2: {}Hz", hal::rcc::clocks().pclk2.0);
 
     // GPIO
-    spawner.spawn(blink(p.PA15.into(), 1000)).unwrap();
-    spawner.spawn(blink(p.PB4.into(), 100)).unwrap();
-    spawner.spawn(blink(p.PB8.into(), 100)).unwrap();
+    spawner.spawn(blink(p.PA15.into(), 1000).unwrap());
+    spawner.spawn(blink(p.PB4.into(), 100).unwrap());
+    spawner.spawn(blink(p.PB8.into(), 100).unwrap());
     let mut tick = 0;
     loop {
         Timer::after_millis(1000).await;

--- a/examples/ch32v307/src/bin/rcc.rs
+++ b/examples/ch32v307/src/bin/rcc.rs
@@ -5,7 +5,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::println;
 use hal::Peri;
 use {ch32_hal as hal, panic_halt as _};

--- a/examples/ch32v307/src/bin/sdi_print.rs
+++ b/examples/ch32v307/src/bin/sdi_print.rs
@@ -24,9 +24,6 @@ fn main() -> ! {
     loop {
         println!("hello world!");
 
-        unsafe {
-            // qingke::riscv::asm::delay(10_000_000);
-            hal::delay::Delay.delay_ms(1000);
-        }
+        hal::delay::Delay.delay_ms(1000);
     }
 }

--- a/examples/ch32v307/src/bin/spi.rs
+++ b/examples/ch32v307/src/bin/spi.rs
@@ -6,7 +6,7 @@
 use ch32_hal::spi;
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::println;
 use hal::time::Hertz;
 use hal::Peri;

--- a/examples/ch32v307/src/bin/spi.rs
+++ b/examples/ch32v307/src/bin/spi.rs
@@ -30,7 +30,7 @@ async fn main(spawner: Spawner) -> ! {
     let p = hal::init(Default::default());
 
     // GPIO
-    spawner.spawn(blink(p.PA0.into())).unwrap();
+    spawner.spawn(blink(p.PA0.into()).unwrap());
     let (sck, miso, mosi) = (p.PA5, p.PA6, p.PA7);
 
     let mut spi_config = spi::Config::default();

--- a/examples/ch32v307/src/bin/uart.rs
+++ b/examples/ch32v307/src/bin/uart.rs
@@ -6,7 +6,7 @@
 use ch32_hal::usart;
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::usart::UartTx;
 use hal::Peri;
 use {ch32_hal as hal, panic_halt as _};
@@ -30,12 +30,12 @@ async fn main(spawner: Spawner) -> ! {
     // GPIO
     spawner.spawn(blink(p.PA0.into()).unwrap());
 
-    let mut cfg = usart::Config::default();
+    let cfg = usart::Config::default();
     let mut uart = UartTx::new_blocking(p.USART1, p.PA9, cfg).unwrap();
 
     loop {
         Timer::after_millis(2000).await;
 
-        uart.blocking_write(b"hello world from embassy main\r\n");
+        let _ = uart.blocking_write(b"hello world from embassy main\r\n");
     }
 }

--- a/examples/ch32v307/src/bin/uart.rs
+++ b/examples/ch32v307/src/bin/uart.rs
@@ -28,7 +28,7 @@ async fn main(spawner: Spawner) -> ! {
     let p = hal::init(Default::default());
 
     // GPIO
-    spawner.spawn(blink(p.PA0.into())).unwrap();
+    spawner.spawn(blink(p.PA0.into()).unwrap());
 
     let mut cfg = usart::Config::default();
     let mut uart = UartTx::new_blocking(p.USART1, p.PA9, cfg).unwrap();

--- a/examples/ch32v307/src/bin/uart_echo.rs
+++ b/examples/ch32v307/src/bin/uart_echo.rs
@@ -4,25 +4,24 @@
 
 
 use embassy_executor::Spawner;
-use embassy_time::{Duration, Timer};
-use hal::gpio::{AnyPin, Level, Output, Pin};
-use hal::usart::{Uart, UartTx};
-use hal::{println, usart};
+use hal::gpio::{Level, Output};
+use hal::usart::{Uart};
+use hal::{usart};
 use {ch32_hal as hal, panic_halt as _};
 
 #[embassy_executor::main(entry = "ch32_hal::entry")]
-async fn main(spawner: Spawner) -> ! {
+async fn main(_spawner: Spawner) -> ! {
     hal::debug::SDIPrint::enable();
     let p = hal::init(Default::default());
 
     // GPIO
     let mut led = Output::new(p.PA4, Level::Low, Default::default());
 
-    let mut cfg = usart::Config::default();
+    let cfg = usart::Config::default();
     //cfg.baudrate = 1000000;
     let mut uart = Uart::new_blocking(p.USART1, p.PA10, p.PA9, cfg).unwrap();
 
-    uart.blocking_write(b"Init ok\r\n");
+    let _ = uart.blocking_write(b"Init ok\r\n");
 
     // FIXME: no time slice for embassy executor
     let mut buf = [0u8; 1];
@@ -34,10 +33,10 @@ async fn main(spawner: Spawner) -> ! {
         }
 
         if buf[0] == b'\r' {
-            uart.blocking_write(b"\r\n").unwrap();
+            let _ = uart.blocking_write(b"\r\n").unwrap();
             led.toggle();
         } else {
-            uart.blocking_write(&buf).unwrap();
+            let _ = uart.blocking_write(&buf).unwrap();
         }
     }
 }

--- a/examples/ch32v307/src/bin/usbfs_dfu.rs
+++ b/examples/ch32v307/src/bin/usbfs_dfu.rs
@@ -20,7 +20,7 @@ const BLOCK_SIZE: usize = 64;
 struct DfuDemoDevice;
 
 impl DfuHandler for DfuDemoDevice {
-    fn write_data(&mut self, offset: usize, data: &[u8]) {
+    fn write_data(&mut self, _offset: usize, _data: &[u8]) {
         // Nothing
     }
 
@@ -28,7 +28,7 @@ impl DfuHandler for DfuDemoDevice {
         // TODO: nothing
     }
 
-    fn upload(&self, buffer: &mut [u8], offset: usize) -> usize {
+    fn upload(&self, _buffer: &mut [u8], _offset: usize) -> usize {
         todo!()
     }
 
@@ -38,7 +38,7 @@ impl DfuHandler for DfuDemoDevice {
 }
 
 #[embassy_executor::main(entry = "qingke_rt::entry")]
-async fn main(spawner: Spawner) -> ! {
+async fn main(_spawner: Spawner) -> ! {
     // setup clocks
     let cfg = Config {
         rcc: ch32_hal::rcc::Config::SYSCLK_FREQ_144MHZ_HSI,

--- a/examples/ch32x035/Cargo.toml
+++ b/examples/ch32x035/Cargo.toml
@@ -11,11 +11,11 @@ ch32-hal = { path = "../../", features = [
     "rt",
     "time-driver-tim2",
 ] }
-embassy-executor = { version = "0.9.1", features = [
-    "arch-spin",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-spin",
     "executor-thread",
 ] }
-embassy-time = "0.5.0"
+embassy-time = "0.5.1"
 
 qingke-rt = "0.7"
 qingke = "0.7"

--- a/examples/ch32x035/src/bin/blinky.rs
+++ b/examples/ch32x035/src/bin/blinky.rs
@@ -29,7 +29,7 @@ async fn main(spawner: Spawner) -> ! {
 
 
     // GPIO
-    spawner.spawn(blink(p.PB12.into(), 1000)).unwrap();
+    spawner.spawn(blink(p.PB12.into(), 1000).unwrap());
 
     loop {
         Timer::after_millis(2000).await;

--- a/examples/ch32x035/src/bin/spi-lcd-st7735.rs
+++ b/examples/ch32x035/src/bin/spi-lcd-st7735.rs
@@ -301,7 +301,7 @@ async fn main(spawner: Spawner) -> ! {
     println!("display init ok");
 
     // GPIO, // T1C4
-    spawner.spawn(blink(led.into())).unwrap();
+    spawner.spawn(blink(led.into()).unwrap());
 
     display.clear(Rgb565::BLACK).unwrap();
 

--- a/examples/ch32x035/src/bin/uart_echo.rs
+++ b/examples/ch32x035/src/bin/uart_echo.rs
@@ -28,7 +28,7 @@ async fn main(spawner: Spawner) -> ! {
     // GPIO
     let mut led = Output::new(p.PB12, Level::High, Default::default());
 
-    uart.blocking_write(b"ready!\r\n").unwrap();
+    let _ = uart.blocking_write(b"ready!\r\n").unwrap();
 
     // FIXME: no time slice for embassy executor
     let mut buf = [0u8; 1];
@@ -40,10 +40,10 @@ async fn main(spawner: Spawner) -> ! {
         }
 
         if buf[0] == b'\r' {
-            uart.blocking_write(b"\r\n").unwrap();
+            let _ = uart.blocking_write(b"\r\n").unwrap();
             led.toggle();
         } else {
-            uart.blocking_write(&buf).unwrap();
+            let _ = uart.blocking_write(&buf).unwrap();
         }
     }
 }

--- a/examples/ch32x035/src/bin/uart_tx_async.rs
+++ b/examples/ch32x035/src/bin/uart_tx_async.rs
@@ -56,7 +56,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // GPIO
     // let mut led = Output::new(p.PB12, Level::High, Default::default());
-    spawner.spawn(blink(p.PB12.into(), 1000)).unwrap();
+    spawner.spawn(blink(p.PB12.into(), 1000).unwrap());
 
     let buf = b"Hello World\r\n";
     loop {

--- a/examples/ch641/Cargo.toml
+++ b/examples/ch641/Cargo.toml
@@ -11,11 +11,11 @@ ch32-hal = { path = "../../", features = [
     "time-driver-tim2",
     "rt",
 ] }
-embassy-executor = { version = "0.9.1", features = [
-    "arch-spin",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-spin",
     "executor-thread",
 ] }
-embassy-time = "0.5.0"
+embassy-time = "0.5.1"
 embedded-hal = "1.0.0"
 
 qingke-rt = "0.7"

--- a/examples/ch641/src/bin/embassy_blinky.rs
+++ b/examples/ch641/src/bin/embassy_blinky.rs
@@ -34,7 +34,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // let mut led = Output::new(p.PB1, Level::Low, Default::default());
 
-    spawner.spawn(blink(p.PB1.into(), 110)).unwrap();
+    spawner.spawn(blink(p.PB1.into(), 110).unwrap());
 
     loop {
         Timer::after_millis(1000).await;

--- a/examples/ch641/src/bin/embassy_blinky.rs
+++ b/examples/ch641/src/bin/embassy_blinky.rs
@@ -7,7 +7,7 @@ use ch32_hal as hal;
 use hal::Peri;
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::println;
 
 #[embassy_executor::task(pool_size = 2)]

--- a/examples/ch641/src/bin/pwm.rs
+++ b/examples/ch641/src/bin/pwm.rs
@@ -4,7 +4,6 @@
 
 
 use hal::delay::Delay;
-use hal::println;
 use hal::time::Hertz;
 use hal::timer::low_level::CountingMode;
 use hal::timer::simple_pwm::{PwmPin, SimplePwm};

--- a/examples/ch643/Cargo.toml
+++ b/examples/ch643/Cargo.toml
@@ -10,11 +10,11 @@ ch32-hal = { path = "../../", features = [
     "embassy",
     "rt",
 ] }
-embassy-executor = { version = "0.9.1", features = [
-    "arch-spin",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-spin",
     "executor-thread",
 ] }
-embassy-time = "0.5.0"
+embassy-time = "0.5.1"
 
 qingke-rt = "0.7"
 qingke = "0.7"

--- a/examples/ch643/src/bin/embassy_blinky.rs
+++ b/examples/ch643/src/bin/embassy_blinky.rs
@@ -7,7 +7,7 @@ use ch32_hal as hal;
 use hal::Peri;
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use hal::gpio::{AnyPin, Level, Output, Pin};
+use hal::gpio::{AnyPin, Level, Output};
 use hal::println;
 
 #[embassy_executor::task(pool_size = 2)]

--- a/examples/ch643/src/bin/embassy_blinky.rs
+++ b/examples/ch643/src/bin/embassy_blinky.rs
@@ -34,7 +34,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // let mut led = Output::new(p.PB17, Level::Low, Default::default());
 
-    spawner.spawn(blink(p.PB17.into(), 500)).unwrap();
+    spawner.spawn(blink(p.PB17.into(), 500).unwrap());
 
     loop {
         Timer::after_millis(1000).await;

--- a/src/flash/common.rs
+++ b/src/flash/common.rs
@@ -166,7 +166,7 @@ pub(super) unsafe fn erase_sector_with_critical_section(sector: &FlashSector) ->
 }
 
 pub(super) fn get_sector(address: u32) -> FlashSector {
-    let mut bank_offset = 0;
+    let _bank_offset = 0;
     let index_in_region = (address - FLASH_BASE as u32) / WRITE_SIZE as u32;
     if (address as usize) < (FLASH_BASE + FLASH_SIZE) {
         return FlashSector {

--- a/src/flash/common.rs
+++ b/src/flash/common.rs
@@ -119,6 +119,7 @@ pub(super) unsafe fn write_chunk_unlocked(address: u32, chunk: &[u8]) -> Result<
     family::blocking_write(address, unwrap!(chunk.try_into()))
 }
 
+#[allow(unused)]
 pub(super) unsafe fn write_chunk_with_critical_section(address: u32, chunk: &[u8]) -> Result<(), Error> {
     critical_section::with(|_| write_chunk_unlocked(address, chunk))
 }
@@ -161,6 +162,7 @@ pub(super) unsafe fn erase_sector_unlocked(sector: &FlashSector) -> Result<(), E
     family::blocking_erase_sector(sector)
 }
 
+#[allow(unused)]
 pub(super) unsafe fn erase_sector_with_critical_section(sector: &FlashSector) -> Result<(), Error> {
     critical_section::with(|_| erase_sector_unlocked(sector))
 }

--- a/src/flash/v3.rs
+++ b/src/flash/v3.rs
@@ -1,5 +1,5 @@
 use core::ptr::write_volatile;
-use core::sync::atomic::{fence, AtomicBool, Ordering};
+use core::sync::atomic::{fence, Ordering};
 
 use super::{FlashSector, WRITE_SIZE};
 use crate::flash::Error;

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -73,6 +73,7 @@ impl From<Pull> for vals::Cnf {
 
 impl Pull {
     #[inline]
+    #[allow(unused)]
     fn to_cnf(&self) -> u8 {
         match self {
             Pull::None => 0b01,

--- a/src/usbpd/mod.rs
+++ b/src/usbpd/mod.rs
@@ -330,7 +330,7 @@ impl<'d, T: Instance + PeripheralType, M: Mode> UsbPdPhy<'d, T, M> {
         T::port_cc_reg(cc1.port_sel()).write(|w| w.set_cc_ce(vals::PortCcCe::V0_66));
         T::port_cc_reg(cc2.port_sel()).write(|w| w.set_cc_ce(vals::PortCcCe::V0_66));
 
-        let mut this = Self {
+        let this = Self {
             _marker: PhantomData,
             cc1: cc1.port_sel(),
             cc2: cc2.port_sel(),


### PR DESCRIPTION
Hello,
i have updated embassy-executor, embassy-time, embassy-future and embassy-sync to the latest version available on lib.rs. No compile error. I think this is connected to #168.  I removed a few compiler warnings for the examples afterwards.
Help by testing the example would be appreciated.