### PR TITLE
Usart: Adapted blocking_flush and added flush().async

### DIFF
--- a/src/usart/mod.rs
+++ b/src/usart/mod.rs
@@ -62,6 +62,12 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
                 // disable idle line detection
                 w.set_idleie(false);
             });
+        } else if cr1.tcie() && sr.tc() {
+        // Transmission complete detected
+        r.ctlr1().modify(|w| {
+            // disable Transmission complete interrupt
+            w.set_tcie(false);
+        });  
         } else if cr1.rxneie() {
             // We cannot check the RXNE flag as it is auto-cleared by the DMA controller
 
@@ -72,6 +78,7 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 
         compiler_fence(Ordering::SeqCst);
         s.rx_waker.wake();
+        s.tx_waker.wake();
     }
 }
 
@@ -223,7 +230,9 @@ impl<'d, T: Instance, M: Mode> UartTx<'d, T, M> {
     /// Block until transmission complete
     pub fn blocking_flush(&mut self) -> Result<(), Error> {
         let rb = T::regs();
-        while !rb.statr().read().tc() {} // wait for last bit on wire.
+        if rb.ctlr1().read().te() {
+            while !rb.statr().read().tc() {} // wait for last bit on wire.
+        }
         Ok(())
     }
 }
@@ -275,6 +284,37 @@ impl<'d, T: Instance> UartTx<'d, T, Async> {
         transfer.await;
         Ok(())
     }
+
+    /// Wait until transmission complete
+    pub async fn flush(&mut self) -> Result<(), Error> {
+        let r = T::regs();
+        if r.ctlr1().read().te() && !r.statr().read().tc() {
+            r.ctlr1().modify(|w| {
+                // enable Transmission Complete interrupt
+                w.set_tcie(true);
+            });
+
+            compiler_fence(Ordering::SeqCst);
+
+            // future which completes when Transmission complete is detected
+            let abort = poll_fn(move |cx| {
+                let s = T::state();
+                s.tx_waker.register(cx.waker());
+
+                let sr = r.statr().read();
+                if sr.tc() {
+                    // Transmission complete detected
+                    return Poll::Ready(());
+                }
+
+                Poll::Pending
+            });
+
+            abort.await;
+        }
+
+        Ok(())
+    }   
 }
 
 impl<'d, T: Instance> UartTx<'d, T, Blocking> {
@@ -1033,13 +1073,16 @@ impl<'d, T: Instance> core::fmt::Write for Uart<'d, T, Blocking> {
 
 // Peripheral traits
 struct State {
+    #[allow(unused)]
     rx_waker: AtomicWaker,
+    tx_waker: AtomicWaker,
 }
 
 impl State {
     const fn new() -> Self {
         Self {
             rx_waker: AtomicWaker::new(),
+            tx_waker: AtomicWaker::new(),
         }
     }
 }


### PR DESCRIPTION
Hello,

as requested by #143 I adapted blocking_flush and added async flush based on embassy-stm32. I tested it with a logic analyzer and CH32V307 and this code:
`tx_uart.write(b"Testmessage").await.unwrap();`
`let _ = tx_uart.flush().await;`
`//tx_uart.blocking_flush().unwrap();`
`led.toggle();`

The logic analyzer showed led toggle after the last message change with my code changes. Without led toggles before end of transmission.