### PR TITLE
examples: adapt eth example to embassy-executor 0.10 spawn API

### DIFF
--- a/examples/ch32v307/src/bin/eth.rs
+++ b/examples/ch32v307/src/bin/eth.rs
@@ -66,7 +66,7 @@ async fn main(spawner: Spawner) -> ! {
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(device, net_config, RESOURCES.init(StackResources::new()), seed);
 
-    spawner.spawn(net_task(runner)).unwrap();
+    spawner.spawn(net_task(runner).unwrap());
 
     println!("Waiting for link...");
     loop {


### PR DESCRIPTION
This fixes the example build failure on main.