### PR TITLE
Fix USB endpoint allocation and disabled endpoint handling.

### DIFF
--- a/src/otg_fs/mod.rs
+++ b/src/otg_fs/mod.rs
@@ -135,10 +135,12 @@ where
     }
 
     fn find_free_ep_address(&self, _dir: Direction) -> Result<u8, embassy_usb_driver::EndpointAllocError> {
-        // Skip index 0 which is reserved for control endpoint
+        // Endpoint 0 is reserved for the control pipe (claimed in start()).
+        // Match the Embassy USB drivers by only auto-allocating non-control
+        // endpoints from index 1.
         Ok(self
             .allocated
-            .next_false_index(0)
+            .next_false_index(1)
             .ok_or(embassy_usb_driver::EndpointAllocError)? as u8)
     }
 
@@ -158,7 +160,9 @@ where
                 }
 
                 let ep_num = addr.index();
-                if ep_num >= MAX_NR_EP {
+                // Endpoint 0 belongs to the control pipe, which claims it in
+                // start(); class endpoint allocation must never hand it out.
+                if ep_num == 0 || ep_num >= MAX_NR_EP {
                     return Err(embassy_usb_driver::EndpointAllocError);
                 }
 

--- a/src/usbhs/endpoint.rs
+++ b/src/usbhs/endpoint.rs
@@ -62,6 +62,13 @@ impl<'d, T: Instance, D: Dir, const SIZE: usize> Endpoint<'d, T, D, SIZE> {
         poll_fn(|ctx| {
             super::EP_WAKERS[index].register(ctx.waker());
 
+            // EP0 has no enable bits (CH32FV2x_V3xRM R32_UEP_CONFIG: "the
+            // transceiver enable signal of endpoint 0 is always valid"), so
+            // is_enabled() is only meaningful for index >= 1.
+            if index != 0 && !self.is_enabled() {
+                return Poll::Ready(Err(EndpointError::Disabled));
+            }
+
             let transfer = d.int_fg().read().transfer();
             let status = r.int_st().read();
             if transfer && status.endp() == index as u8 {
@@ -121,6 +128,11 @@ impl<'d, T: Instance, D: Dir, const SIZE: usize> Endpoint<'d, T, D, SIZE> {
 
         poll_fn(|ctx| {
             EP_WAKERS[index].register(ctx.waker());
+
+            // EP0 has no enable bits (see data_out), so skip the check here.
+            if index != 0 && !self.is_enabled() {
+                return Poll::Ready(Err(EndpointError::Disabled));
+            }
 
             let transfer = d.int_fg().read().transfer();
             let status = r.int_st().read();

--- a/src/usbhs/mod.rs
+++ b/src/usbhs/mod.rs
@@ -398,7 +398,23 @@ impl<'d, T: Instance> embassy_usb_driver::Bus for Bus<'d, T> {
                 T::dregs().ep_config().modify(|v| v.set_r_en(index - 1, enabled));
                 T::dregs().ep_rx_ctrl(index).write(|v| {
                     v.set_mask_uep_r_tog(EpTog::DATA0);
-                    v.set_mask_uep_r_res(EpRxResponse::NAK);
+                    // Make OUT endpoints ready as soon as the selected
+                    // configuration enables them. Embassy drivers such as RP2040
+                    // mark OUT buffers available in endpoint_set_enabled(), and
+                    // hosts may send the first OUT packet immediately after the
+                    // SET_CONFIGURATION status stage.
+                    //
+                    // Arming early is safe even before the class task calls
+                    // read(): with RB_UC_INT_BUSY set (see Driver::new), the
+                    // SIE auto-responds NAK while UIF_TRANSFER is pending, so
+                    // the DMA buffer cannot be overwritten until data_out()
+                    // consumes the packet and clears the flag.
+                    // See CH32FV2x_V3xRM R8_USB_CTRL.RB_UC_INT_BUSY.
+                    v.set_mask_uep_r_res(if enabled {
+                        EpRxResponse::ACK
+                    } else {
+                        EpRxResponse::NAK
+                    });
                     v.set_r_tog_auto(false);
                 });
             }

--- a/src/usbhs/mod.rs
+++ b/src/usbhs/mod.rs
@@ -343,6 +343,10 @@ impl<'d, T: Instance> Bus<'d, T> {
         d.ep_config().write_value(EpConfig::default());
         d.ep_type().write_value(EpType::default());
         d.ep_buf_mod().write_value(EpBufMod::default());
+
+        for waker in EP_WAKERS.iter() {
+            waker.wake();
+        }
     }
 }
 

--- a/src/usbhs/mod.rs
+++ b/src/usbhs/mod.rs
@@ -188,8 +188,10 @@ impl<'d, T: Instance, const NR_EP: usize, const SIZE: usize> Driver<'d, T, NR_EP
     }
 
     fn find_free_ep_address(&self, _dir: Direction) -> Result<u8, EndpointAllocError> {
-        // Skip index 0 which is reserved for control endpoint
-        Ok(self.allocated.next_false_index(0).ok_or(EndpointAllocError)? as u8)
+        // Endpoint 0 is reserved for the control pipe (claimed in start()).
+        // Match the Embassy USB drivers by only auto-allocating non-control
+        // endpoints from index 1.
+        Ok(self.allocated.next_false_index(1).ok_or(EndpointAllocError)? as u8)
     }
 
     fn alloc_endpoint<D: Dir>(
@@ -208,7 +210,9 @@ impl<'d, T: Instance, const NR_EP: usize, const SIZE: usize> Driver<'d, T, NR_EP
                 }
 
                 let ep_num = addr.index();
-                if ep_num >= MAX_NR_EP {
+                // Endpoint 0 belongs to the control pipe, which claims it in
+                // start(); class endpoint allocation must never hand it out.
+                if ep_num == 0 || ep_num >= MAX_NR_EP {
                     return Err(EndpointAllocError);
                 }
 


### PR DESCRIPTION
- Reserve endpoint 0 exclusively for the control pipe by starting automatic endpoint allocation at index 1.
- Reject explicit class endpoint allocations that attempt to claim endpoint 0.
- Return `EndpointError::Disabled` when polling disabled non-control USBHS endpoints.
- Wake endpoint tasks when disabling USBHS endpoints so pending operations can observe the disabled state.
- Configure enabled OUT endpoints to ACK immediately, allowing hosts to send data right after `SET_CONFIGURATION`.