### PR TITLE
chore: use released ch32-metapac 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 ch32-metapac = { features = [
     "rt",
-], git = "https://github.com/ch32-rs/ch32-metapac", rev = "23d667214e30fae690c739d27efca4cfe0e042d0" }
+], version = "0.1.0" }
 
 qingke = { version = "0.7", features = ["critical-section-impl"] }
 qingke-rt = { version = "0.7", optional = true }
@@ -56,7 +56,7 @@ embedded-storage = "0.3.1"
 [build-dependencies]
 ch32-metapac = { features = [
     "metadata",
-], git = "https://github.com/ch32-rs/ch32-metapac", rev = "23d667214e30fae690c739d27efca4cfe0e042d0" }
+], version = "0.1.0" }
 
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+# ch32-data rev = a515903589cfbc342dc6ad0d13c02b4382da5628
 ch32-metapac = { features = [
     "rt",
 ], version = "0.1.0" }
@@ -54,6 +55,7 @@ sdio-host = "0.5.0"
 embedded-storage = "0.3.1"
 
 [build-dependencies]
+# ch32-data rev = a515903589cfbc342dc6ad0d13c02b4382da5628
 ch32-metapac = { features = [
     "metadata",
 ], version = "0.1.0" }


### PR DESCRIPTION
This updates the HAL to use the released `ch32-metapac` 0.1.0 crate instead of pinning the generated git revision directly.

Validation run locally against the current CI HAL matrix:

```text
cargo build --features <chip>,embassy,rt,memory-x --no-default-features --target <target>
```

Checked chips:
- ch32l103f8u6 / riscv32imc-unknown-none-elf
- ch32v003f4u6 / riscv32i-unknown-none-elf
- ch32v006k8u6 / riscv32i-unknown-none-elf
- ch32v103c8t6 / riscv32imc-unknown-none-elf
- ch32v203f8u6 / riscv32imc-unknown-none-elf
- ch32v208wbu6 / riscv32imc-unknown-none-elf
- ch32v303cbt6 / riscv32imc-unknown-none-elf
- ch32v305fbp6 / riscv32imc-unknown-none-elf
- ch32v307vct6 / riscv32imc-unknown-none-elf
- ch32x035f7p6 / riscv32imc-unknown-none-elf
- ch641 / riscv32i-unknown-none-elf
- ch643 / riscv32imc-unknown-none-elf
