### PR TITLE
feat(dma): gate auto-generated DMA channel ISRs behind dma-isrs feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 
 [features]
-default = ["embassy", "rt", "exti"]
+default = ["embassy", "rt", "exti", "dma-isrs"]
 rt = ["dep:qingke-rt", "rt-wfi"]
 highcode = ["qingke-rt/highcode"]
 embassy = [
@@ -74,6 +74,8 @@ defmt = ["dep:defmt"]
 memory-x = ["ch32-metapac/memory-x"]
 ## Built-in EXTI driver and interrupt handlers. Disable to provide your own.
 exti = []
+## Built-in DMA channel ISRs. Disable to provide your own handlers; the async DMA APIs will then have no way to wake their wakers.
+dma-isrs = []
 
 
 # Features starting with `_` are for internal use only. They're not intended

--- a/build.rs
+++ b/build.rs
@@ -628,7 +628,7 @@ fn main() {
             let channels = channels.iter().map(|c| format_ident!("{}", c));
 
             quote! {
-                #[cfg(feature = "rt")]
+                #[cfg(all(feature = "rt", feature = "dma-isrs"))]
                 #[qingke_rt::interrupt]
                 unsafe fn #irq () {
                     #(

--- a/examples/ch32l103/Cargo.toml
+++ b/examples/ch32l103/Cargo.toml
@@ -9,6 +9,7 @@ ch32-hal = { path = "../../", features = [
     "memory-x",
     "embassy",
     "rt",
+    "dma-isrs",
     "time-driver-tim2",
 ], default-features = false }
 embassy-executor = { version = "0.10.0", features = [

--- a/examples/ch32v203/Cargo.toml
+++ b/examples/ch32v203/Cargo.toml
@@ -14,6 +14,7 @@ ch32-hal = { path = "../../", features = [
     "memory-x",
     "embassy",
     "rt",
+    "dma-isrs",
     "time-driver-tim2",
 ], default-features = false }
 

--- a/examples/ch32v208/Cargo.toml
+++ b/examples/ch32v208/Cargo.toml
@@ -9,6 +9,7 @@ ch32-hal = { path = "../../", features = [
     "memory-x",
     "embassy",
     "rt",
+    "dma-isrs",
 ], default-features = false }
 embassy-executor = { version = "0.10.0", features = [
     "platform-spin",


### PR DESCRIPTION
## Summary

Adds a `dma-isrs` feature (in defaults) that controls whether `build.rs` emits `#[interrupt]` handlers for the DMA1/DMA2 channel vectors. Default-on preserves current behavior. Downstream crates that supply their own `#[interrupt] fn DMA1_CHANNELx()` handlers can now opt out with `default-features = false` + selective re-enable, instead of getting a "symbol multiply defined" link error.

The three examples that already use `default-features = false` (ch32v203, ch32v208, ch32l103) get `dma-isrs` added explicitly so any future async-DMA bins in them keep working.

## Motivation

Surfaced while building a wire-side measurement tool on CH32V203 that owns its own DMA1_CHANNEL3/CH5/CH6 ISRs (USART3 RX + TIM2/TIM3 input-capture). Without the gate, those handlers collide with the generated stubs at link time and there's no clean way to opt out short of forking `build.rs`.

## Behavior

- `default-features = true` (or any features list containing `dma-isrs`): unchanged — stubs generated, async DMA APIs (Transfer, ringbuffer, copy_*) work.
- `default-features = false` without `dma-isrs`: no stubs generated, async DMA APIs compile but their wakers never fire — caller is responsible for handling DMA interrupts.