### PR TITLE
Update README support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For a full list of chip capabilities and peripherals, check the [ch32-data](http
 | UART\*     | ✅    | ✅  | ✅   | ❓   | ✅   | ✅   | ❓    | ❓    |
 | SPI\*      | ✅    | ✅  | ✅   | ❓   | ✅   | ✅   | N/A   | ❓    |
 | SDIO\*     | ✅    | N/A | N/A  | N/A  | N/A  | N/A  | N/A   | N/A   |
-| I2C        | ✅    | ✅  | ✅   | ❓   | ❓   | ❓   | ❓    | ❓    |
+| I2C\*      | ✅    | ✅  | ✅   | ❓   | ❓   | ❓   | ❓    | ❓    |
 | ADC        | ✅    | ✅  | ✅   | ✅   | ✅   | ✅   | ✅    | ✅    |
 | DAC\*      | ✅    | N/A | N/A  | N/A  | N/A  | N/A  | N/A   | N/A   |
 | FLASH      | ✅    | ✅  | ✅   | ✅   | ✅   | ✅   | ✅    | ✅    |

--- a/README.md
+++ b/README.md
@@ -40,8 +40,12 @@ For a full list of chip capabilities and peripherals, check the [ch32-data](http
 | EXTI\*     | ✅    | ✅  | ✅   | ✅   | ✅   | ✅   | ✅    | ✅    |
 | UART\*     | ✅    | ✅  | ✅   | ❓   | ✅   | ✅   | ❓    | ❓    |
 | SPI\*      | ✅    | ✅  | ✅   | ❓   | ✅   | ✅   | N/A   | ❓    |
+| SDIO\*     | ✅    | N/A | N/A  | N/A  | N/A  | N/A  | N/A   | N/A   |
 | I2C        | ✅    | ✅  | ✅   | ❓   | ❓   | ❓   | ❓    | ❓    |
 | ADC        | ✅    | ✅  | ✅   | ✅   | ✅   | ✅   | ✅    | ✅    |
+| DAC\*      | ✅    | N/A | N/A  | N/A  | N/A  | N/A  | N/A   | N/A   |
+| FLASH      | ✅    | ✅  | ✅   | ✅   | ✅   | ✅   | ✅    | ✅    |
+| RNG\*      | ✅    | N/A | N/A  | N/A  | N/A  | N/A  | N/A   | N/A   |
 | Timer(PWM) | ✅    | ✅  | ✅   | ❓   | ✅   | ✅   | ✅    | ✅    |
 | USBD       | ✅\*  | N/A | N/A  | N/A  | N/A  | N/A  | N/A   | N/A   |
 | USB/OTG FS | ✅\*  | N/A | N/A  | N/A  | N/A  | N/A  | N/A   | N/A   |


### PR DESCRIPTION
I almost didn't use rust due to missing README support table
Should we add DMA to the table too?