### PR TITLE
Complete I2C slave implementation with blocking and async + DMA modes

### DIFF
--- a/examples/ch32v203/Cargo.toml
+++ b/examples/ch32v203/Cargo.toml
@@ -8,6 +8,10 @@ name = "usbd"
 path = "src/bin/usbd.rs"
 required-features = ["embassy-executor/arch-spin"]
 
+[[bin]]
+name = "i2c_slave_async"
+path = "src/bin/i2c_slave_async.rs"
+
 [dependencies]
 ch32-hal = { path = "../../", features = [
     "ch32v203g6u6",

--- a/examples/ch32v203/src/bin/i2c_slave_async.rs
+++ b/examples/ch32v203/src/bin/i2c_slave_async.rs
@@ -1,0 +1,54 @@
+#![no_std]
+#![no_main]
+
+use ch32_hal::i2c::{I2c, SlaveConfig, SlaveAddress, SlaveCommand};
+use ch32_hal::time::Hertz;
+use embassy_executor::Spawner;
+use {ch32_hal as hal, panic_halt as _};
+
+hal::bind_interrupts!(struct Irqs {
+    I2C1_EV => hal::i2c::EventInterruptHandler<hal::peripherals::I2C1>;
+    I2C1_ER => hal::i2c::ErrorInterruptHandler<hal::peripherals::I2C1>;
+});
+
+#[embassy_executor::main(entry = "qingke_rt::entry")]
+async fn main(_spawner: Spawner) -> ! {
+    let p = hal::init(Default::default());
+
+    let i2c_master = I2c::new(
+        p.I2C1,
+        p.PB8,
+        p.PB9,
+        Irqs,
+        p.DMA1_CH6,
+        p.DMA1_CH7,
+        Hertz::khz(100),
+        Default::default(),
+    );
+
+    let mut slave = i2c_master.into_slave(SlaveConfig {
+        address: SlaveAddress::SevenBit(0x50),
+        general_call: false,
+    });
+
+    let mut rx_buf = [0u8; 64];
+    let tx_data = b"Hello from CH32V203 I2C slave";
+
+    loop {
+        match slave.listen().await {
+            Ok(SlaveCommand::WriteCommand) => {
+                match slave.read(&mut rx_buf).await {
+                    Ok(_received_bytes) => {
+                        // handle received data
+                    }
+                    Err(_) => {}
+                }
+            }
+            Ok(SlaveCommand::ReadCommand) => {
+                let _ = slave.write(tx_data).await;
+            }
+            Ok(SlaveCommand::GeneralCall) => {}
+            Err(_) => {}
+        }
+    }
+}

--- a/src/dma/dma_bdma.rs
+++ b/src/dma/dma_bdma.rs
@@ -251,7 +251,7 @@ impl AnyChannel {
         }
     }
 
-    fn get_remaining_transfers(&self) -> u16 {
+    pub fn get_remaining_transfers(&self) -> u16 {
         let info = self.info();
         match self.info().dma {
             DmaInfo::Dma(r) => r.ch(info.num).ndtr().read().ndt(),

--- a/src/dma/util.rs
+++ b/src/dma/util.rs
@@ -56,4 +56,9 @@ impl<'d> ChannelAndRequest<'d> {
     ) -> Transfer<'a> {
         Transfer::new_write_repeated(self.channel.reborrow(), self.request, repeated, count, peri_addr, options)
     }
+
+    /// Returns the number of bytes remaining in the current DMA transfer.
+    pub fn remaining_bytes(&self) -> usize {
+        self.channel.get_remaining_transfers() as usize
+    }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -267,6 +267,38 @@ impl<'d, T: Instance, M: Mode> I2c<'d, T, M, Master> {
 
         regs.ctlr1().modify(|w| w.set_pe(true));
     }
+
+    /// configure device for slave mode operation using supplied i2c addresses
+    pub fn into_slave(mut self, slave_config: SlaveConfig) -> I2c<'d, T, M, Slave> {
+        T::regs().ctlr1().modify(|w| w.set_pe(false));
+        T::regs().ctlr1().modify(|w| w.set_engc(slave_config.general_call));
+        match slave_config.address {
+            SlaveAddress::SevenBit(addr) => T::regs().oaddr1().modify(|w| {
+                w.set_addmode(false);
+                // not documentet in every version of the reference manual
+                // specific bit needs to be 1, no further utility
+                w.set_must1(true);
+                w.set_add7_1(addr);
+            }),
+            SlaveAddress::TenBit(addr) => T::regs().oaddr1().modify(|w| {
+                w.set_addmode(true);
+                // not documentet in every version of the reference manual
+                // specific bit needs to be 1, no further utility
+                w.set_must1(true);
+                w.set_add9_8((addr >> 8) as u8);
+                w.set_add7_1((addr >> 1) as u8);
+                w.set_add0(addr & 0x0001 == 0x0001);
+            }),
+        }
+        T::regs().ctlr1().modify(|w| w.set_pe(true));
+        I2c::<'d, T, M, Slave> {
+            tx_dma: self.tx_dma.take(),
+            rx_dma: self.rx_dma.take(),
+            #[cfg(feature = "embassy")]
+            timeout: self.timeout,
+            _phantom: PhantomData,
+        }
+    }
 }
 
 impl<'d, T: Instance, M: Mode, O: OperatingMode> I2c<'d, T, M, O> {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -599,6 +599,106 @@ impl<'d, T: Instance> I2c<'d, T, Async, Slave> {
             Err(err) => Err((received, err)),
         }
     }
+
+    /// Async send bytes to master after [`SlaveCommand::ReadCommand`].
+    ///
+    /// Uses DMA to transfer data from buffer to I2C data register.
+    /// Returns Ok when master stops reading or NACKs.
+    pub async fn write(&mut self, data: &[u8]) -> Result<(), Error> {
+        // acking is the masters job on slave response
+        T::regs().ctlr1().modify(|w| w.set_ack(false));
+
+        let on_drop = OnDrop::new(|| {
+            T::regs().ctlr2().modify(|w| {
+                w.set_dmaen(false);
+                w.set_iterren(false);
+                w.set_itevten(false);
+            });
+        });
+
+        let state = T::state();
+
+        T::regs().ctlr2().modify(|w| {
+            w.set_itbufen(false);
+            w.set_dmaen(true);
+            w.set_last(false);
+        });
+
+        let dma_transfer = unsafe {
+            let dst = T::regs().datar().as_ptr() as *mut u8;
+            self.tx_dma.as_mut().unwrap().write(data, dst, Default::default())
+        };
+
+        // clearing address flag starts response
+        T::regs().star1().modify(|w| w.set_addr(false));
+
+        let poll_events = poll_fn(|cx| {
+            state.waker.register(cx.waker());
+
+            let star1 = T::regs().star1().read();
+
+            if star1.stopf() {
+                Poll::Ready(Ok::<(), Error>(()))
+            } else {
+                match Self::check_and_clear_error_flags() {
+                    Err(e) => {
+                        T::regs().ctlr1().modify(|w| w.set_swrst(true));
+                        T::regs().ctlr1().modify(|w| w.set_swrst(false));
+                        Poll::Ready(Err(e))
+                    }
+                    Ok(_) => {
+                        Self::enable_interrupts();
+                        Poll::Pending
+                    }
+                }
+            }
+        });
+
+        let result = match select(dma_transfer, poll_events).await {
+            Either::Second(Err(e)) => Err(e),
+            Either::First(_) => {
+                // when dma tranfer is finished, disable dma interrupt
+                // enable normal buffer events to wait for last transmission
+                // to finish
+                T::regs().ctlr2().modify(|w| {
+                    w.set_itbufen(true);
+                    w.set_dmaen(false);
+                });
+                // wait for last transfer to complete
+                let _ = poll_fn(|cx| {
+                    state.waker.register(cx.waker());
+
+                    let star1 = T::regs().star1().read();
+                    if star1.tx_e() {
+                        Poll::Ready(())
+                    } else {
+                        Self::enable_interrupts();
+                        Poll::Pending
+                    }
+                })
+                .await;
+                // if the master expects more bytes than the transfer
+                // was configured to send, this releases the SCL and
+                // SDA line as the slave, otherwise the bus might be locked
+                // up indefinitly
+                T::regs().ctlr1().modify(|w| w.set_stop(true));
+                Ok(())
+            }
+            _ => Ok(()),
+        };
+
+        let star1 = T::regs().star1().read();
+        if star1.af() {
+            T::regs().star1().modify(|w| w.set_af(false));
+        } else if star1.stopf() {
+            T::regs().ctlr1().modify(|w| w.set_swrst(false));
+        }
+
+        drop(on_drop);
+
+        // Fallthrough is success
+        Ok(())
+    }
 }
 
 impl<'d, T: Instance, M: Mode, O: OperatingMode> I2c<'d, T, M, O> {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -466,6 +466,66 @@ impl<'d, T: Instance, M: Mode> I2c<'d, T, M, Slave> {
     }
 }
 
+impl<'d, T: Instance> I2c<'d, T, Async, Slave> {
+    #[inline]
+    fn enable_interrupts() {
+        T::regs().ctlr2().modify(|w| {
+            w.set_itevten(true);
+            w.set_iterren(true);
+        });
+    }
+
+    /// Async wait for master to address us and return the command type.
+    ///
+    /// This is the async version of [`Self::listen_blocking`].
+    pub async fn listen(&mut self) -> Result<SlaveCommand, Error> {
+        T::regs().ctlr1().modify(|w| w.set_pe(true));
+
+        if !T::regs().ctlr1().read().ack() {
+            let _ = Self::check_and_clear_error_flags();
+            T::regs().ctlr1().modify(|w| w.set_ack(true));
+        }
+
+        let state = T::state();
+
+        poll_fn(|cx| {
+            state.waker.register(cx.waker());
+
+            let star1 = T::regs().star1().read();
+
+            if star1.addr() {
+                let star2 = T::regs().star2().read();
+
+                if star2.gencall() {
+                    Poll::Ready(Ok(SlaveCommand::GeneralCall))
+                } else if star2.tra() {
+                    Poll::Ready(Ok(SlaveCommand::ReadCommand))
+                } else {
+                    Poll::Ready(Ok(SlaveCommand::WriteCommand))
+                }
+            } else {
+                match Self::check_and_clear_error_flags() {
+                    Err(e) => {
+                        T::regs().ctlr1().modify(|w| w.set_swrst(true));
+                        T::regs().ctlr1().modify(|w| w.set_swrst(false));
+                        Poll::Ready(Err(e))
+                    }
+                    Ok(_) => {
+                        // with some bus error states, the i2c peripheral might reset and unset acknoledge
+                        // if this happens without triggering a different error state we might never poll again
+                        // leading to the listen never returing, force setting ack here prevents the likelyhood
+                        // of this happeing signifcantly
+                        T::regs().ctlr1().modify(|w| w.set_ack(true));
+                        Self::enable_interrupts();
+                        Poll::Pending
+                    }
+                }
+            }
+        })
+        .await
+    }
+}
+
 impl<'d, T: Instance, M: Mode, O: OperatingMode> I2c<'d, T, M, O> {
     fn timeout(&self) -> Timeout {
         Timeout {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -524,6 +524,81 @@ impl<'d, T: Instance> I2c<'d, T, Async, Slave> {
         })
         .await
     }
+
+    /// Async receive bytes from master after [`SlaveCommand::WriteCommand`].
+    ///
+    /// Uses DMA to transfer data from I2C data register to buffer.
+    /// Returns actual number of bytes received or error with partial count.
+    pub async fn read(&mut self, buf: &mut [u8]) -> Result<usize, (usize, Error)> {
+        T::regs().ctlr2().modify(|w| {
+            // ifbufen needs to be disabled with dma
+            w.set_itbufen(false);
+            w.set_dmaen(true);
+            w.set_last(false); // only relevant for master mode, just keep it off
+        });
+
+        let on_drop = OnDrop::new(|| {
+            T::regs().ctlr2().modify(|w| {
+                w.set_dmaen(false);
+                w.set_iterren(false);
+                w.set_itevten(false);
+            });
+        });
+
+        let state = T::state();
+
+        let dma_transfer = unsafe {
+            let dst = T::regs().datar().as_ptr() as *mut u8;
+            self.rx_dma.as_mut().unwrap().read(dst, buf, Default::default())
+        };
+
+        // release clock stretch and start transfer from master to slave
+        T::regs().star1().modify(|w| w.set_addr(false));
+
+        let poll_events = poll_fn(|cx| {
+            state.waker.register(cx.waker());
+
+            match Self::check_and_clear_error_flags() {
+                Err(e) => {
+                    // on error soft reset
+                    T::regs().ctlr1().modify(|w| w.set_swrst(true));
+                    T::regs().ctlr1().modify(|w| w.set_swrst(false));
+                    Poll::Ready(Err(e))
+                }
+                Ok(star1) => {
+                    if star1.stopf() {
+                        T::regs().ctlr1().modify(|w| w.set_swrst(false));
+                        Poll::Ready(Ok::<(), Error>(()))
+                    } else {
+                        Self::enable_interrupts();
+                        Poll::Pending
+                    }
+                }
+            }
+        });
+
+        let result = match select(dma_transfer, poll_events).await {
+            Either::Second(Err(e)) => Err(e),
+            Either::Second(Ok(_)) => Ok(()),
+            Either::First(_) => {
+                // dma transfer finished no more bytes will be received
+                // if master tries to send more a nack should be triggered
+                T::regs().ctlr1().modify(|w| w.set_ack(false));
+                T::regs().ctlr2().modify(|w| w.set_dmaen(false));
+
+                Ok(())
+            }
+        };
+
+        let remaining = self.rx_dma.as_ref().unwrap().remaining_bytes();
+        let received = buf.len() - remaining;
+
+        drop(on_drop);
+        match result {
+            Ok(_) => Ok(received),
+            Err(err) => Err((received, err)),
+        }
+    }
 }
 
 impl<'d, T: Instance, M: Mode, O: OperatingMode> I2c<'d, T, M, O> {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -342,6 +342,46 @@ impl<'d, T: Instance, M: Mode> I2c<'d, T, M, Slave> {
             }
         }
     }
+
+    /// call this after receiving [`SlaveCommand::WriteCommand`] to receive data from master
+    pub fn blocking_read(&mut self, recv_buf: &mut [u8]) -> Result<usize, (usize, Error)> {
+        //clear addr status to start receiving bytes
+        T::regs().star1().modify(|w| w.set_addr(false));
+
+        let mut received_bytes = 0;
+        while received_bytes <= recv_buf.len() {
+            let star1 = T::regs().star1().read();
+            // received data \o/
+            if star1.rx_ne() && received_bytes == recv_buf.len() {
+                //received more data than fits in buffer
+                T::regs().ctlr1().modify(|w| w.set_stop(true));
+                T::regs().ctlr1().modify(|w| w.set_swrst(false));
+                return Err((received_bytes, Error::Overrun));
+            } else if star1.rx_ne() && received_bytes < recv_buf.len() {
+                recv_buf[received_bytes] = T::regs().datar().read().datar();
+                received_bytes += 1;
+
+                if received_bytes == recv_buf.len() {
+                    // the last byte that fits the buffer was just received
+                    // so any further byte can not be processed
+                    T::regs().ctlr1().modify(|w| w.set_ack(false));
+                }
+            } else if star1.stopf() {
+                // master stopped sending data, return early
+                T::regs().ctlr1().modify(|w| w.set_swrst(false));
+                return Ok(received_bytes);
+            } else {
+                // check for any error states
+                Self::check_and_clear_error_flags().map_err(|err| (received_bytes, err))?;
+            }
+        }
+        // this should no be reachable, earlier exits in the loop are expected
+        // using unreachable would be possible! but returning is probably better for
+        // stability reasons
+        Ok(received_bytes)
+    }
+
+    }
 }
 
 impl<'d, T: Instance, M: Mode, O: OperatingMode> I2c<'d, T, M, O> {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -7,6 +7,7 @@ use core::task::Poll;
 use embassy_futures::select::{select, Either};
 use embassy_sync::waitqueue::AtomicWaker;
 use embedded_hal::i2c::Operation;
+use mode::{OperatingMode, Master, Slave};
 
 use crate::dma::ChannelAndRequest;
 use crate::gpio::{AFType, Speed};
@@ -15,6 +16,27 @@ use crate::mode::{Async, Blocking, Mode};
 // use crate::interrupt::Interrupt;
 use crate::time::Hertz;
 use crate::{interrupt, peripherals, Peri, Timeout};
+
+/// I2C modes
+pub mod mode {
+    trait SealedMode {}
+
+    /// Trait for I2C master operations.
+    #[allow(private_bounds)]
+    pub trait OperatingMode: SealedMode {}
+
+
+    /// Mode allowing for I2C master operations.
+    pub struct Master;
+    /// Mode allowing for I2C slave operations.
+    pub struct Slave;
+
+    impl SealedMode for Master {}
+    impl OperatingMode for Master {}
+
+    impl SealedMode for Slave {}
+    impl OperatingMode for Slave {}
+}
 
 /// Event interrupt handler.
 pub struct EventInterruptHandler<T: Instance> {
@@ -88,6 +110,24 @@ pub struct Config {
     pub duty: Duty,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum SlaveAddress {
+    SevenBit(u8),
+    TenBit(u16)
+}
+
+/// I2C config for slave mode operation
+///
+/// Configure the address the I2C device will consider its address. 10- and 7-Bit addresses are supported.
+/// It is also possible to configure responsding to detecting a general call.
+///
+/// Note: ch32 devices support dual addressing mode. This mode of operation has not been implemented!
+#[derive(Copy, Clone)]
+pub struct SlaveConfig {
+    pub address: SlaveAddress,
+    pub general_call: bool,
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -99,15 +139,15 @@ impl Default for Config {
 }
 
 /// I2C driver.
-pub struct I2c<'d, T: Instance, M: Mode> {
+pub struct I2c<'d, T: Instance, M: Mode, O: OperatingMode> {
     tx_dma: Option<ChannelAndRequest<'d>>,
     rx_dma: Option<ChannelAndRequest<'d>>,
     #[cfg(feature = "embassy")]
     timeout: embassy_time::Duration,
-    _phantom: PhantomData<(&'d mut T, M)>,
+    _phantom: PhantomData<(&'d mut T, M, O)>,
 }
 
-impl<'d, T: Instance> I2c<'d, T, Async> {
+impl<'d, T: Instance> I2c<'d, T, Async, Master> {
     /// Create a new I2C driver.
     pub fn new<const REMAP: u8>(
         peri: Peri<'d, T>,
@@ -125,7 +165,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
     }
 }
 
-impl<'d, T: Instance> I2c<'d, T, Blocking> {
+impl<'d, T: Instance> I2c<'d, T, Blocking, Master> {
     /// Create a new blocking I2C driver.
     pub fn new_blocking<const REMAP: u8>(
         peri: Peri<'d, T>,
@@ -138,7 +178,7 @@ impl<'d, T: Instance> I2c<'d, T, Blocking> {
     }
 }
 
-impl<'d, T: Instance, M: Mode> I2c<'d, T, M> {
+impl<'d, T: Instance, M: Mode> I2c<'d, T, M, Master> {
     /// Create a new I2C driver.
     fn new_inner<const REMAP: u8>(
         _peri: Peri<'d, T>,
@@ -174,22 +214,13 @@ impl<'d, T: Instance, M: Mode> I2c<'d, T, M> {
             _phantom: PhantomData,
         };
 
-        this.init(freq, config);
+        this.init_master(freq, config);
 
         this
     }
 
-    fn timeout(&self) -> Timeout {
-        Timeout {
-            #[cfg(feature = "embassy")]
-            deadline: embassy_time::Instant::now() + self.timeout,
-        }
-    }
-}
-
-impl<'d, T: Instance, M: Mode> I2c<'d, T, M> {
     // init as master mode
-    fn init(&mut self, freq: Hertz, config: Config) {
+    fn init_master(&mut self, freq: Hertz, config: Config) {
         let regs = T::regs();
 
         regs.ctlr1().modify(|w| w.set_pe(false)); // disale i2c
@@ -236,6 +267,15 @@ impl<'d, T: Instance, M: Mode> I2c<'d, T, M> {
 
         regs.ctlr1().modify(|w| w.set_pe(true));
     }
+}
+
+impl<'d, T: Instance, M: Mode, O: OperatingMode> I2c<'d, T, M, O> {
+    fn timeout(&self) -> Timeout {
+        Timeout {
+            #[cfg(feature = "embassy")]
+            deadline: embassy_time::Instant::now() + self.timeout,
+        }
+    }
 
     fn check_and_clear_error_flags() -> Result<crate::pac::i2c::regs::Star1, Error> {
         // Note that flags should only be cleared once they have been registered. If flags are
@@ -276,7 +316,9 @@ impl<'d, T: Instance, M: Mode> I2c<'d, T, M> {
 
         Ok(star1)
     }
+}
 
+impl<'d, T: Instance, M: Mode> I2c<'d, T, M, Master> {
     fn write_bytes(&mut self, addr: u8, bytes: &[u8], timeout: Timeout, frame: FrameOptions) -> Result<(), Error> {
         if frame.send_start() {
             // Send a START condition
@@ -485,7 +527,7 @@ impl<'d, T: Instance, M: Mode> I2c<'d, T, M> {
 
 // ======== Async
 
-impl<'d, T: Instance> I2c<'d, T, Async> {
+impl<'d, T: Instance> I2c<'d, T, Async, Master> {
     async fn write_frame(&mut self, address: u8, write: &[u8], frame: FrameOptions) -> Result<(), Error> {
         T::regs().ctlr2().modify(|w| {
             // Note: Do not enable the ITBUFEN bit in the I2C_CR2 register if DMA is used for
@@ -837,7 +879,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
 
 // ======== Common
 
-impl<'d, T: Instance, M: Mode> Drop for I2c<'d, T, M> {
+impl<'d, T: Instance, M: Mode, O: OperatingMode> Drop for I2c<'d, T, M, O> {
     fn drop(&mut self) {
         T::regs().ctlr1().modify(|w| w.set_pe(false));
     }
@@ -910,11 +952,11 @@ impl embedded_hal::i2c::Error for Error {
     }
 }
 
-impl<'d, T: Instance, M: Mode> embedded_hal::i2c::ErrorType for I2c<'d, T, M> {
+impl<'d, T: Instance, M: Mode> embedded_hal::i2c::ErrorType for I2c<'d, T, M, Master> {
     type Error = Error;
 }
 
-impl<'d, T: Instance, M: Mode> embedded_hal::i2c::I2c for I2c<'d, T, M> {
+impl<'d, T: Instance, M: Mode> embedded_hal::i2c::I2c for I2c<'d, T, M, Master> {
     fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
         self.blocking_read(address, read)
     }
@@ -927,6 +969,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal::i2c::I2c for I2c<'d, T, M> {
         self.blocking_write_read(address, write, read)
     }
 
+    /// not implemented!
     fn transaction(
         &mut self,
         address: u8,
@@ -938,7 +981,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal::i2c::I2c for I2c<'d, T, M> {
     }
 }
 
-impl<'d, T: Instance> embedded_hal_async::i2c::I2c for I2c<'d, T, Async> {
+impl<'d, T: Instance> embedded_hal_async::i2c::I2c for I2c<'d, T, Async, Master> {
     async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
         self.read(address, read).await
     }
@@ -951,6 +994,8 @@ impl<'d, T: Instance> embedded_hal_async::i2c::I2c for I2c<'d, T, Async> {
         self.write_read(address, write, read).await
     }
 
+
+    /// not yet implemented!
     async fn transaction(
         &mut self,
         address: u8,
@@ -964,7 +1009,7 @@ impl<'d, T: Instance> embedded_hal_async::i2c::I2c for I2c<'d, T, Async> {
 
 // eh02 compatible
 
-impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Read for I2c<'d, T, M> {
+impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Read for I2c<'d, T, M, Master> {
     type Error = Error;
 
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
@@ -972,7 +1017,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Read for I2c<'d, 
     }
 }
 
-impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Write for I2c<'d, T, M> {
+impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Write for I2c<'d, T, M, Master> {
     type Error = Error;
 
     fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
@@ -980,7 +1025,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Write for I2c<'d,
     }
 }
 
-impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::WriteRead for I2c<'d, T, M> {
+impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::WriteRead for I2c<'d, T, M, Master> {
     type Error = Error;
 
     fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -7,7 +7,7 @@ use core::task::Poll;
 use embassy_futures::select::{select, Either};
 use embassy_sync::waitqueue::AtomicWaker;
 use embedded_hal::i2c::Operation;
-use mode::{OperatingMode, Master, Slave};
+use mode::{Master, OperatingMode, Slave};
 
 use crate::dma::ChannelAndRequest;
 use crate::gpio::{AFType, Speed};
@@ -24,7 +24,6 @@ pub mod mode {
     /// Trait for I2C master operations.
     #[allow(private_bounds)]
     pub trait OperatingMode: SealedMode {}
-
 
     /// Mode allowing for I2C master operations.
     pub struct Master;
@@ -113,7 +112,7 @@ pub struct Config {
 #[derive(Debug, Clone, Copy)]
 pub enum SlaveAddress {
     SevenBit(u8),
-    TenBit(u16)
+    TenBit(u16),
 }
 
 /// I2C config for slave mode operation
@@ -126,6 +125,16 @@ pub enum SlaveAddress {
 pub struct SlaveConfig {
     pub address: SlaveAddress,
     pub general_call: bool,
+}
+
+#[derive(Debug)]
+pub enum SlaveCommand {
+    /// received general call addresse, can process incoming data
+    GeneralCall,
+    /// received read command, will enter transmitter mode to respond with data
+    ReadCommand,
+    /// received write command, should read incoming data
+    WriteCommand,
 }
 
 impl Default for Config {
@@ -291,12 +300,46 @@ impl<'d, T: Instance, M: Mode> I2c<'d, T, M, Master> {
             }),
         }
         T::regs().ctlr1().modify(|w| w.set_pe(true));
+
         I2c::<'d, T, M, Slave> {
             tx_dma: self.tx_dma.take(),
             rx_dma: self.rx_dma.take(),
             #[cfg(feature = "embassy")]
             timeout: self.timeout,
             _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'d, T: Instance, M: Mode> I2c<'d, T, M, Slave> {
+    pub fn listen_blocking(&mut self) -> Result<SlaveCommand, Error> {
+        #[cfg(feature = "embassy")]
+        let timout = self.timeout();
+
+        T::regs().ctlr1().modify(|w| w.set_pe(true));
+        // clear status to remove and dirty state before starting listen if ack has not been enabled yet
+        if !T::regs().ctlr1().read().ack() {
+            let _ = Self::check_and_clear_error_flags();
+            // enable ACK to let master now the device is alive
+            T::regs().ctlr1().modify(|w| w.set_ack(true));
+        }
+
+        // blocking wait for addresse receive
+        while !T::regs().star1().read().addr() {
+            #[cfg(feature = "embassy")]
+            timout.check().ok_or(Error::Timeout)?;
+        }
+
+        let star2 = T::regs().star2().read();
+
+        if star2.gencall() {
+            Ok(SlaveCommand::GeneralCall)
+        } else {
+            if star2.tra() {
+                Ok(SlaveCommand::ReadCommand)
+            } else {
+                Ok(SlaveCommand::WriteCommand)
+            }
         }
     }
 }
@@ -1025,7 +1068,6 @@ impl<'d, T: Instance> embedded_hal_async::i2c::I2c for I2c<'d, T, Async, Master>
     async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
         self.write_read(address, write, read).await
     }
-
 
     /// not yet implemented!
     async fn transaction(

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -311,6 +311,11 @@ impl<'d, T: Instance, M: Mode> I2c<'d, T, M, Master> {
     }
 }
 
+enum TransmissionState {
+    Continue,
+    Finished,
+}
+
 impl<'d, T: Instance, M: Mode> I2c<'d, T, M, Slave> {
     pub fn listen_blocking(&mut self) -> Result<SlaveCommand, Error> {
         #[cfg(feature = "embassy")]
@@ -381,6 +386,83 @@ impl<'d, T: Instance, M: Mode> I2c<'d, T, M, Slave> {
         Ok(received_bytes)
     }
 
+    fn check_transmission_state(&mut self) -> Result<TransmissionState, Error> {
+        match Self::check_and_clear_error_flags() {
+            Err(err) => Err(err),
+            Ok(star1) => {
+                if star1.stopf() {
+                    T::regs().ctlr1().modify(|w| w.set_swrst(false));
+                    Ok(TransmissionState::Finished)
+                } else {
+                    Ok(TransmissionState::Continue)
+                }
+            }
+        }
+    }
+
+    /// call this after receiving [`SlaveCommand::ReadCommand`] to send data to master
+    pub fn blocking_write(&mut self, trans_buf: &[u8]) -> Result<(), Error> {
+        // disable ack in send mode the slave does not send ack
+        T::regs().ctlr1().modify(|w| w.set_ack(false));
+
+        //clear addr status to start transmission
+        T::regs().star1().modify(|w| w.set_addr(false));
+
+        for (i, b) in trans_buf.iter().enumerate() {
+            // wait for current byte transfer to be finished
+            let mut tx_e = T::regs().star1().read().tx_e();
+            while !tx_e {
+                tx_e = T::regs().star1().read().tx_e();
+                // theoretically the following check should be done after
+                // a small timeout at the position of this comment. Master nack is
+                // delayed to tx_e state change, so if the master sends a nack
+                // the slave might already try to send the next byte and can not
+                // detect that it was not received by the master
+                // (in case master expects less data) than slave sends
+                // so slave can only detect nack errors on send to expected byte differences
+                // bigger than 1 byte. This is quite an edge case and introducing a timer requirement
+                // for accurate delay seems like more hassle that it's worth to fix the case.
+                // Especially since in the general case master know how many bytes to receive
+                match self.check_transmission_state() {
+                    Err(err) => {
+                        T::regs().ctlr1().modify(|w| w.set_stop(true));
+                        T::regs().ctlr1().modify(|w| w.set_swrst(false));
+                        return Err(err);
+                    }
+                    Ok(TransmissionState::Finished) => {
+                        // last byte was not sent yet
+                        T::regs().ctlr1().modify(|w| w.set_stop(true));
+                        T::regs().ctlr1().modify(|w| w.set_swrst(false));
+                        return Err(Error::Nack);
+                    }
+                    Ok(TransmissionState::Continue) => {}
+                }
+            }
+
+            T::regs().datar().write(|w| w.set_datar(*b));
+        }
+
+        // wait for stop event to occur
+        while !T::regs().star1().read().tx_e() {
+            match self.check_transmission_state() {
+                Err(Error::Nack) => {
+                    // all bytes where already sent, last nack is expected
+                    break;
+                }
+                Err(err) => {
+                    T::regs().ctlr1().modify(|w| w.set_stop(true));
+                    T::regs().ctlr1().modify(|w| w.set_swrst(false));
+                    return Err(err);
+                }
+                _ => {}
+            }
+        }
+        // according to the ref manual, when this is set in slave mode
+        // te slave device will release SDA and SLC after the pending transfer
+        T::regs().ctlr1().modify(|w| w.set_stop(true));
+
+        // all bytes sent and stop bit received
+        Ok(())
     }
 }
 


### PR DESCRIPTION
I finally got around to cleaning up and fully testing the i2c slave integration I have been working on.

As opposed to #164 this PR integrates i2c slave logic into the existing i2c logic. This allows reusing a lot of the 
infrastructure for things like using DMA for fully asynchronous receive and transfer. This might also allow for 
future expansion to switch between master and slave mode for multi master i2c, though that is out of scope for this PR.

I put a lot of effort into testing different edge cases and trying to prevent failure modes where the slave could pull 
SDA or SCL low forever, which would effectively lock up the I2C bus for all connected devices. I think the driver is now very robust. Testing included measuring the actual transfers with and oscilloscope to check the actual behavior of the device
under edge case scenarios such as master sending more or less than the expected amount of data for write command and the
corresponding edge cases in read mode.

I have tested the code for `ch32v203` not any other devices of the HAL family.

Cheers
ju6ge